### PR TITLE
lib: Check addresses for proper alignment and boundaries

### DIFF
--- a/src/util/util.rs
+++ b/src/util/util.rs
@@ -80,6 +80,22 @@ macro_rules! ALIGN {
     };
 }
 
+/// Check if x is aligned to y
+#[macro_export]
+macro_rules! ALIGNED {
+    ($x: expr, $y: expr) => {
+        ($x == ALIGN!(($x), ($y)))
+    };
+}
+
+/// Check if address is 2MB aligned
+#[macro_export]
+macro_rules! PAGE_2MB_ALIGNED {
+    ($x: expr) => {
+        ALIGNED!($x, PAGE_2MB_SIZE)
+    };
+}
+
 /// Retrieve number of pages that a given value contains
 #[macro_export]
 macro_rules! PAGE_COUNT {


### PR DESCRIPTION
Configurable SVSM_GPA should be page aligned -as of today, this means 2MB
alignment. Same goes for SVSM_MEM (total size). Furthermore, the start and
end of dynamic memory should be within boundaries. Add checks at the
beginning of Rust code.

Signed-off-by: Carlos Bilbao <carlos.bilbao@amd.com>