### PR TITLE
linker: Add static assert for SVSM_GPA_LDS alignment

### DIFF
--- a/src/start/svsm.lds.S
+++ b/src/start/svsm.lds.S
@@ -2,7 +2,8 @@
 /*
  * Copyright (C) 2022 Advanced Micro Devices, Inc.
  *
- * Author: Tom Lendacky <thomas.lendacky@amd.com>
+ * Author: Tom Lendacky <thomas.lendacky@amd.com> and
+ *	   Carlos Bilbao <carlos.bilbao@amd.com>
  */
 
 #include "svsm.h"
@@ -50,4 +51,6 @@ SECTIONS
 		*(.note.GNU-stack)
 		*(.note.gnu.build-id)
 	}
+
+	. = ASSERT(!(SVSM_GPA_LDS & 0xfffff), "SVSM_GPA not 2MB aligned! make clean and try again...");
 }


### PR DESCRIPTION
Configurable SVSM_GPA_LDS (derived from SVSM_GPA in Makefile) is only checked for proper alignment dynamically, through SVSM_GPA in the Rust section.

Include assert check for alignment in the linker.

Signed-off-by: Carlos Bilbao <carlos.bilbao@amd.com>