### PR TITLE
Minor fixes to readme and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ form of the error, running manually with -v. In our case:
 
 ```
 $ cd ovmf
-$ nice build -v -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n 32 -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc
+$ source edksetup.sh
+$ nice build -v -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT -n 32 -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc
 ```
 
 If your error involves still not finding Python, you can try the following

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -104,7 +104,8 @@ build_install_ovmf()
 		GCCVERS="GCC5"
 	fi
 
-	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n $(getconf _NPROCESSORS_ONLN) ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
+	# captures all the OVMF debug messages on qemu serial log. remove -DDEBUG_ON_SERIAL_PORT to disable it.
+	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT -n $(getconf _NPROCESSORS_ONLN) ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
 
 	[ -d ovmf ] || {
 		run_cmd git clone --single-branch -b ${OVMF_BRANCH} ${OVMF_GIT_URL} ovmf


### PR DESCRIPTION
* Add a comment on how to disable the OVMF debug messages (if needed)
* Update the README to invoke the `build` command in case of a failure