### PR TITLE
scripts: move SPDX identifier after shebang

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 SCRIPT_DIR="$(dirname $0)"
 . ${SCRIPT_DIR}/common.sh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 run_cmd()
 {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 [ -e /etc/os-release ] && . /etc/os-release
 

--- a/scripts/launch-qemu.sh
+++ b/scripts/launch-qemu.sh
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 #
 # user changeable parameters


### PR DESCRIPTION
The scripts should start with a shebang line to be interpreted by the shell that was specified in the file.

Reviewed-by: Carlos Bilbao <carlos.bilbao@amd.com>
Signed-off-by: Vikram Narayanan <vikram186@gmail.com>