### PR TITLE
change mod.rs files to use {} for pub declarations

### DIFF
--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -17,24 +17,16 @@ pub mod ghcb;
 /// Page Table and its related operations
 pub mod pgtable;
 
-pub use crate::mem::alloc::mem_allocate;
-pub use crate::mem::alloc::mem_allocate_frame;
-pub use crate::mem::alloc::mem_allocate_frames;
-pub use crate::mem::alloc::mem_free;
-pub use crate::mem::alloc::mem_free_frame;
-pub use crate::mem::alloc::mem_free_frames;
-pub use crate::mem::alloc::mem_init;
+pub use crate::mem::alloc::{
+    mem_allocate, mem_allocate_frame, mem_allocate_frames, mem_free, mem_free_frame,
+    mem_free_frames, mem_init,
+};
 
-pub use crate::mem::pgtable::pgtable_init;
-pub use crate::mem::pgtable::pgtable_make_pages_np;
-pub use crate::mem::pgtable::pgtable_make_pages_nx;
-pub use crate::mem::pgtable::pgtable_make_pages_private;
-pub use crate::mem::pgtable::pgtable_make_pages_shared;
-pub use crate::mem::pgtable::pgtable_map_pages_private;
-pub use crate::mem::pgtable::pgtable_pa_to_va;
-pub use crate::mem::pgtable::pgtable_va_to_pa;
+pub use crate::mem::pgtable::{
+    pgtable_init, pgtable_make_pages_np, pgtable_make_pages_nx, pgtable_make_pages_private,
+    pgtable_make_pages_shared, pgtable_map_pages_private, pgtable_pa_to_va, pgtable_va_to_pa,
+};
 
 pub use crate::mem::ghcb::ghcb_init;
 
-pub use crate::mem::fwcfg::fwcfg_init;
-pub use crate::mem::fwcfg::fwcfg_map_bios;
+pub use crate::mem::fwcfg::{fwcfg_init, fwcfg_map_bios};

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -13,5 +13,4 @@ pub mod serial;
 /// Auxiliary functions and macros
 pub mod util;
 
-pub use crate::util::serial::serial_init;
-pub use crate::util::serial::serial_out;
+pub use crate::util::serial::{serial_init, serial_out};


### PR DESCRIPTION
change pub declarations in mod.rs files to use {} format instead of one declaration per line, i.e.

pub use crate::x:y::{fn1, fn2};

instead of:

pub use crate::x::y::fn1;
pub use crate::x::y::fn2;

Signed-off-by: Ben Cheatham <Benjamin.Cheatham@amd.com>