### PR TITLE
switch to a stable version of `size_of` API

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -12,7 +12,7 @@ use crate::cpu::vc::*;
 use crate::*;
 
 use core::cmp::min;
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use core::ptr::copy_nonoverlapping;
 use uuid::Bytes;
 use uuid::Uuid;

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -15,7 +15,7 @@ use crate::percpu::alloc::vec::Vec;
 use crate::*;
 
 use core::arch::asm;
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use memoffset::offset_of;
 use x86_64::addr::*;
 use x86_64::structures::paging::PhysFrame;

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -15,7 +15,7 @@ use crate::mem::*;
 use crate::svsm_request::*;
 use crate::*;
 
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use x86_64::addr::{PhysAddr, VirtAddr};
 use x86_64::instructions::tables::{sgdt, sidt};
 use x86_64::registers::control::Cr3;

--- a/src/cpu/tss.rs
+++ b/src/cpu/tss.rs
@@ -8,7 +8,7 @@
 
 use crate::mem::pgtable::*;
 use crate::*;
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use x86_64::instructions::tables::load_tss;
 use x86_64::registers::segmentation::SegmentSelector;
 use x86_64::structures::paging::PhysFrame;

--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -21,7 +21,7 @@ use crate::*;
 
 use alloc::vec::Vec;
 use core::arch::asm;
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use x86_64::addr::PhysAddr;
 use x86_64::addr::VirtAddr;
 use x86_64::structures::idt::*;

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -10,7 +10,7 @@ use crate::globals::*;
 use crate::STATIC_ASSERT;
 use crate::{funcs, BIT};
 
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use memoffset::offset_of;
 use paste::paste;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
  *          Tom Lendacky <thomas.lendacky@amd.com>
  */
 
-#![feature(core_intrinsics)]
 #![feature(type_ascription)]
 #![feature(abi_x86_interrupt)]
 #![feature(alloc_error_handler)]

--- a/src/mem/fwcfg.rs
+++ b/src/mem/fwcfg.rs
@@ -17,7 +17,7 @@ use crate::util::util::memset;
 use crate::*;
 
 use alloc::vec::Vec;
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use core::ptr::copy_nonoverlapping;
 use lazy_static::lazy_static;
 use memchr::memchr;

--- a/src/mem/ghcb.rs
+++ b/src/mem/ghcb.rs
@@ -18,7 +18,7 @@ use crate::util::util::memset;
 use crate::BIT;
 use crate::STATIC_ASSERT;
 
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use core::ptr::copy_nonoverlapping;
 use memoffset::offset_of;
 use paste::paste;

--- a/src/svsm_request.rs
+++ b/src/svsm_request.rs
@@ -23,7 +23,7 @@ use crate::*;
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::intrinsics::size_of;
+use core::mem::size_of;
 use lazy_static::lazy_static;
 use x86_64::addr::{PhysAddr, VirtAddr};
 use x86_64::instructions::tlb::flush;


### PR DESCRIPTION
Both these functions gives the same output for our purposes, i.e., `sizeof(struct)`. By switching to a stable API, we can get rid of the nightly-features(#28), in an effort to switch the build to a standard rust version.

Signed-off-by: Vikram Narayanan <vikram186@gmail.com>