### PR TITLE
fix: PerCpu::apic_id_for()

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -142,7 +142,7 @@ impl PerCpu {
 
             let p: *const PerCpu =
                 (PERCPU_VA.as_u64() + (for_id as u64 * PERCPU_SIZE)) as *const PerCpu;
-            apic_id = (*p).cpu_id;
+            apic_id = (*p).apic_id;
         }
 
         apic_id


### PR DESCRIPTION
Instead of returning `cpu_id` it should return `apic_id`.

Fixes: https://github.com/AMDESE/linux-svsm/issues/32

Signed-off-by: Harald Hoyer <harald@profian.com>