### PR TITLE
Add rust-toolchain file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,8 @@ prereq: .prereq
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 	source $(HOME)/.cargo/env
 	echo "source $(HOME)/.cargo/env" >> ~/.bashrc
-	rustup +nightly target add x86_64-unknown-none
 	rustup component add rust-src
 	rustup component add llvm-tools-preview
-	rustup override set nightly
 	cargo install xargo
 	cargo install bootimage
 	touch .prereq

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+targets = ["x86_64-unknown-none"]


### PR DESCRIPTION
Add a rust-toolchain.toml.
It sets channel and target for the project without the need to run `make prereq` first.