### PR TITLE
build: linux: try to use config.gz if /boot/config is misisng

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -61,7 +61,7 @@ build_kernel()
 				run_cmd git checkout current/${BRANCH}
 				COMMIT=$(git log --format="%h" -1 HEAD)
 
-				run_cmd "cp /boot/config-$(uname -r) .config"
+				run_cmd "cp /boot/config-$(uname -r) .config || zcat /proc/config.gz > .config"
 				run_cmd ./scripts/config --set-str LOCALVERSION "$VER-$COMMIT"
 				run_cmd ./scripts/config --disable LOCALVERSION_AUTO
 				run_cmd ./scripts/config --enable  DEBUG_INFO


### PR DESCRIPTION
Some system do not have /boot/config. Try to use /proc/config.gz in that case when building linux.