### PR TITLE
Add MapGuard to automatically unmap virtual memory

### DIFF
--- a/src/bios.rs
+++ b/src/bios.rs
@@ -13,7 +13,7 @@ use crate::*;
 
 use core::cmp::min;
 use core::mem::size_of;
-use core::ptr::copy_nonoverlapping;
+use core::slice;
 use uuid::Bytes;
 use uuid::Uuid;
 use x86_64::{PhysAddr, VirtAddr};
@@ -283,21 +283,20 @@ unsafe fn advertise_svsm_presence(bios_info: &mut BiosInfo, caa: PhysAddr) -> bo
     };
 
     let bios_cpuid_pa: PhysAddr = PhysAddr::new(section.address_u64());
+    let size: u64 = min(section.size_u64(), get_svsm_cpuid_page_size());
 
-    let bios_cpuid_va: VirtAddr = match pgtable_map_pages_private(bios_cpuid_pa, section.size_u64())
-    {
-        Ok(v) => v,
+    let mut bios_cpuid_map: MapGuard = match MapGuard::new_private(bios_cpuid_pa, size) {
+        Ok(m) => m,
         Err(_e) => return false,
     };
+    let bios_cpuid: &mut [u8] = bios_cpuid_map.as_bytes_mut();
+
     let svsm_cpuid_va: VirtAddr = get_svsm_cpuid_page();
+    let svsm_cpuid_ptr: *const u8 = svsm_cpuid_va.as_ptr();
+    let svsm_cpuid: &[u8] = unsafe { slice::from_raw_parts(svsm_cpuid_ptr, size as usize) };
 
     // Copy the CPUID page to the BIOS Secrets page location
-    let bios_cpuid: *mut u8 = bios_cpuid_va.as_mut_ptr();
-    let svsm_cpuid: *const u8 = svsm_cpuid_va.as_ptr();
-    let size: u64 = min(section.size_u64(), get_svsm_cpuid_page_size());
-    copy_nonoverlapping(svsm_cpuid, bios_cpuid, size as usize);
-
-    pgtable_unmap_pages(bios_cpuid_va, section.size_u64());
+    bios_cpuid.copy_from_slice(svsm_cpuid);
 
     true
 }

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -243,14 +243,12 @@ pub fn smp_run_bios_vmpl() -> bool {
             return false;
         }
 
-        let vmsa_va: VirtAddr = match pgtable_map_pages_private(vmsa_pa, PAGE_SIZE) {
+        let vmsa_map: MapGuard = match MapGuard::new_private(vmsa_pa, PAGE_SIZE) {
             Ok(r) => r,
             Err(_e) => return false,
         };
 
-        vc_ap_create(vmsa_va, PERCPU.apic_id());
-
-        pgtable_unmap_pages(vmsa_va, PAGE_SIZE);
+        vc_ap_create(vmsa_map.va(), PERCPU.apic_id());
     }
 
     true

--- a/src/mem/fwcfg.rs
+++ b/src/mem/fwcfg.rs
@@ -239,8 +239,8 @@ fn find_file_selector(fname: &str) -> Option<u16> {
     return None;
 }
 
-/// Privately map BIOS
-pub fn fwcfg_map_bios() -> Option<(VirtAddr, u64)> {
+/// Returns the GPA and size of the area in which the bios is loaded
+pub fn fwcfg_get_bios_area() -> Option<(PhysAddr, u64)> {
     let bios_pa: u64;
     let bios_size: u64;
 
@@ -264,12 +264,7 @@ pub fn fwcfg_map_bios() -> Option<(VirtAddr, u64)> {
         None => return None,
     };
 
-    let bios_va: VirtAddr = match pgtable_map_pages_private(PhysAddr::new(bios_pa), bios_size) {
-        Ok(b) => b,
-        Err(_e) => return None,
-    };
-
-    Some((bios_va, bios_size))
+    Some((PhysAddr::new(bios_pa), bios_size))
 }
 
 /// Perform DMA to read firmware configuration files

--- a/src/mem/map_guard.rs
+++ b/src/mem/map_guard.rs
@@ -1,0 +1,113 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Copyright (C) 2023 IBM Corporation
+ *
+ * Authors: Dov Murik <dovmurik@linux.ibm.com>
+ */
+
+use crate::getter_func;
+use crate::mem::pgtable::{
+    pgtable_map_pages_private, pgtable_map_pages_shared, pgtable_unmap_pages,
+};
+
+use core::slice;
+use x86_64::structures::paging::mapper::MapToError;
+use x86_64::structures::paging::page::Size4KiB;
+use x86_64::{PhysAddr, VirtAddr};
+
+/// An area mapped into virtual memory. If `unmap_on_drop` is true, the
+/// area is unmapped when the `MapGuard` is dropped (out of scope).
+///
+/// # Examples
+///
+/// ```
+/// fn work() -> Result<()> {
+///   let map1 = MapGuard::new_private(gpa, size)?;
+///   // view the memory as a C struct
+///   let req: &MyRequestStruct = map1.as_object();
+///   let map2 = MapGuard::new_private(gpa2, size)?; // <--- an error here will cause map1 to unmap
+///   // view the memory as a slice of bytes with the correct size (the entire mapped area)
+///   let buf: &[u8] = map2.as_bytes();
+///
+///   // read from the mapped memory
+///   if some_condition {
+///     return Err(...); // here both areas are unmapped
+///   }
+///
+///   Ok(())
+///   // here both areas are unmapped
+/// }
+/// ```
+
+pub struct MapGuard {
+    pa: PhysAddr,
+    va: VirtAddr,
+    len: u64,
+    unmap_on_drop: bool,
+}
+
+impl MapGuard {
+    /// Map an area to virtual memory as private (encrypted) pages; when
+    /// the MapGuard is dropped, the area will be unmapped.
+    pub fn new_private(pa: PhysAddr, len: u64) -> Result<Self, MapToError<Size4KiB>> {
+        let va: VirtAddr = pgtable_map_pages_private(pa, len)?;
+        Ok(Self {
+            pa,
+            va,
+            len,
+            unmap_on_drop: true,
+        })
+    }
+
+    /// Map an area to virtual memory as private (encrypted) pages but
+    /// don't unmap it when the MapGuard is dropped.
+    pub fn new_private_persistent(pa: PhysAddr, len: u64) -> Result<Self, MapToError<Size4KiB>> {
+        let va: VirtAddr = pgtable_map_pages_private(pa, len)?;
+        Ok(Self {
+            pa,
+            va,
+            len,
+            unmap_on_drop: false,
+        })
+    }
+
+    /// Map an area to virtual memory as shared (plaintext) pages; when
+    /// the MapGuard is dropped, the area will be unmapped.
+    pub fn new_shared(pa: PhysAddr, len: u64) -> Result<Self, MapToError<Size4KiB>> {
+        let va: VirtAddr = pgtable_map_pages_shared(pa, len)?;
+        Ok(Self {
+            pa,
+            va,
+            len,
+            unmap_on_drop: true,
+        })
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.va.as_ptr(), self.len as usize) }
+    }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.va.as_mut_ptr(), self.len as usize) }
+    }
+
+    pub fn as_object<T>(&self) -> &T {
+        unsafe { &slice::from_raw_parts::<T>(self.va.as_ptr() as *const _, 1)[0] }
+    }
+
+    pub fn as_object_mut<T>(&mut self) -> &mut T {
+        unsafe { &mut slice::from_raw_parts_mut::<T>(self.va.as_mut_ptr() as *mut _, 1)[0] }
+    }
+
+    getter_func!(pa, PhysAddr);
+    getter_func!(va, VirtAddr);
+    getter_func!(len, u64);
+}
+
+impl Drop for MapGuard {
+    fn drop(&mut self) {
+        if self.unmap_on_drop {
+            pgtable_unmap_pages(self.va, self.len);
+        }
+    }
+}

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -14,6 +14,8 @@ pub mod ca;
 pub mod fwcfg;
 /// Guest Host Communication Block support
 pub mod ghcb;
+/// MapGuard
+pub mod map_guard;
 /// Page Table and its related operations
 pub mod pgtable;
 
@@ -28,6 +30,8 @@ pub use crate::mem::pgtable::{
     pgtable_pa_to_va, pgtable_print_pte_pa, pgtable_print_pte_va, pgtable_unmap_pages,
     pgtable_va_to_pa,
 };
+
+pub use crate::mem::map_guard::MapGuard;
 
 pub use crate::mem::ghcb::ghcb_init;
 

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -35,4 +35,4 @@ pub use crate::mem::map_guard::MapGuard;
 
 pub use crate::mem::ghcb::ghcb_init;
 
-pub use crate::mem::fwcfg::{fwcfg_init, fwcfg_map_bios};
+pub use crate::mem::fwcfg::{fwcfg_get_bios_area, fwcfg_init};

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -26,8 +26,7 @@ pub use crate::mem::alloc::{
 
 pub use crate::mem::pgtable::{
     pgtable_init, pgtable_make_pages_np, pgtable_make_pages_nx, pgtable_make_pages_private,
-    pgtable_make_pages_shared, pgtable_map_pages_private, pgtable_map_pages_shared,
-    pgtable_pa_to_va, pgtable_print_pte_pa, pgtable_print_pte_va, pgtable_unmap_pages,
+    pgtable_make_pages_shared, pgtable_pa_to_va, pgtable_print_pte_pa, pgtable_print_pte_va,
     pgtable_va_to_pa,
 };
 

--- a/src/mem/pgtable.rs
+++ b/src/mem/pgtable.rs
@@ -419,7 +419,7 @@ unsafe fn __pgtable_init(flags: PageTableFlags, allocator: &mut PageTableAllocat
 }
 
 /// Unmap pages
-pub fn pgtable_unmap_pages(va: VirtAddr, len: u64) -> bool {
+pub(crate) fn pgtable_unmap_pages(va: VirtAddr, len: u64) -> bool {
     assert!(len != 0);
 
     let mut map: VirtAddr = va.align_down(PAGE_SIZE);
@@ -450,12 +450,18 @@ pub fn pgtable_unmap_pages(va: VirtAddr, len: u64) -> bool {
 ///
 /// If a previous mapping exists and does not conform to the new mapping, the
 /// previous mapping is replaced by the new mapping.
-pub fn pgtable_map_pages_private(pa: PhysAddr, len: u64) -> Result<VirtAddr, MapToError<Size4KiB>> {
+pub(crate) fn pgtable_map_pages_private(
+    pa: PhysAddr,
+    len: u64,
+) -> Result<VirtAddr, MapToError<Size4KiB>> {
     unsafe { __map_pages(pa, len, PageType::Private) }
 }
 
 /// Map pages as shared
-pub fn pgtable_map_pages_shared(pa: PhysAddr, len: u64) -> Result<VirtAddr, MapToError<Size4KiB>> {
+pub(crate) fn pgtable_map_pages_shared(
+    pa: PhysAddr,
+    len: u64,
+) -> Result<VirtAddr, MapToError<Size4KiB>> {
     unsafe { __map_pages(pa, len, PageType::Shared) }
 }
 

--- a/src/svsm_request.rs
+++ b/src/svsm_request.rs
@@ -11,15 +11,13 @@ use crate::cpu::vc_run_vmpl;
 use crate::cpu::vmsa::Vmsa;
 use crate::globals::*;
 use crate::mem::ca::Ca;
-use crate::mem::pgtable_map_pages_private;
-use crate::mem::pgtable_unmap_pages;
 use crate::protocols::error_codes::*;
 use crate::protocols::*;
 use crate::vmsa_list::*;
 use crate::*;
 
 use alloc::string::String;
-use x86_64::addr::{PhysAddr, VirtAddr};
+use x86_64::addr::PhysAddr;
 
 /// 0x403
 const VMEXIT_VMGEXIT: u64 = 0x403;
@@ -34,107 +32,55 @@ unsafe fn handle_request(vmsa: *mut Vmsa) {
     }
 }
 
-fn map_gpa(gpa: PhysAddr, len: u64) -> Result<VirtAddr, String> {
-    if gpa == PhysAddr::zero() {
-        let msg: String = alloc::format!("map_gpa: gpa cannot be zero");
+pub fn svsm_request_add_init_vmsa(vmsa_pa: PhysAddr, apic_id: u32) {
+    VMSA_LIST.push(vmsa_pa, apic_id);
+}
+
+fn process_one_request(vmpl: VMPL) -> Result<(), String> {
+    //
+    // Limit the mapping of guest memory to only what is needed to process
+    // the request.
+    //
+    let caa_gpa: PhysAddr = unsafe { PERCPU.caa(vmpl) };
+    let mut ca_map: MapGuard = match MapGuard::new_private(caa_gpa, CAA_MAP_SIZE) {
+        Ok(m) => m,
+        Err(e) => return Err(alloc::format!("Error mapping guest calling area: {e:?}")),
+    };
+
+    let vmsa_gpa: PhysAddr = unsafe { PERCPU.vmsa(vmpl) };
+    let mut vmsa_map: MapGuard = match MapGuard::new_private(vmsa_gpa, VMSA_MAP_SIZE) {
+        Ok(m) => m,
+        Err(e) => return Err(alloc::format!("Error mapping guest VMSA: {e:?}")),
+    };
+
+    if !vmsa_clear_efer_svme(vmsa_map.va()) {
+        let msg: String = alloc::format!("map_guest_input: vmsa_clear_efer_svme() failed");
         return Err(msg);
     }
 
-    let va: VirtAddr = match pgtable_map_pages_private(gpa, len) {
-        Ok(r) => r,
-        Err(e) => {
-            let msg: String = alloc::format!("map_gpa: {:?}", e);
-            return Err(msg);
-        }
-    };
+    let vmsa: &mut Vmsa = vmsa_map.as_object_mut();
+    let ca: &mut Ca = ca_map.as_object_mut();
 
-    Ok(va)
-}
+    if vmsa.guest_exitcode() == VMEXIT_VMGEXIT && ca.call_pending() == 1 {
+        unsafe { handle_request(&mut *vmsa) };
+        ca.set_call_pending(0);
+    }
 
-fn unmap_vmsa(va: VirtAddr) {
-    pgtable_unmap_pages(va, VMSA_MAP_SIZE);
-}
-
-fn map_vmsa(vmpl: VMPL) -> Result<VirtAddr, String> {
-    unsafe { map_gpa(PERCPU.vmsa(vmpl), VMSA_MAP_SIZE) }
-}
-
-fn unmap_ca(va: VirtAddr) {
-    pgtable_unmap_pages(va, CAA_MAP_SIZE);
-}
-
-fn map_ca(vmpl: VMPL) -> Result<VirtAddr, String> {
-    unsafe { map_gpa(PERCPU.caa(vmpl), CAA_MAP_SIZE) }
-}
-
-fn unmap_guest_input(ca_va: VirtAddr, vmsa_va: VirtAddr) {
     //
     // Set EFER.SVME to 1 to allow the VMSA to be run by the hypervisor.
     //
-    vmsa_set_efer_svme(vmsa_va);
+    vmsa_set_efer_svme(vmsa_map.va());
 
-    unmap_vmsa(vmsa_va);
-    unmap_ca(ca_va);
-}
-
-fn map_guest_input(vmpl: VMPL) -> Result<(VirtAddr, VirtAddr), String> {
-    let ca_va: VirtAddr = match map_ca(vmpl) {
-        Ok(r) => r,
-        Err(e) => {
-            return Err(e);
-        }
-    };
-
-    let vmsa_va: VirtAddr = match map_vmsa(vmpl) {
-        Ok(r) => r,
-        Err(e) => {
-            unmap_ca(ca_va);
-            return Err(e);
-        }
-    };
-
-    //
-    // Set EFER.SVME to 0 to prevent the hypervisor from trying to
-    // run the vCPU while a request is being handled.
-    //
-    if !vmsa_clear_efer_svme(vmsa_va) {
-        unmap_vmsa(vmsa_va);
-        unmap_ca(ca_va);
-
-        let msg: String = alloc::format!("map_guest_input: clr_vmsa_efer_svme() failed");
-        return Err(msg);
-    }
-
-    Ok((ca_va, vmsa_va))
-}
-
-pub fn svsm_request_add_init_vmsa(vmsa_pa: PhysAddr, apic_id: u32) {
-    VMSA_LIST.push(vmsa_pa, apic_id);
+    Ok(())
 }
 
 /// Process SVSM requests
 pub fn svsm_request_loop() {
     loop {
-        //
-        // Limit the mapping of guest memory to only what is needed to process
-        // the request.
-        //
-        match map_guest_input(VMPL::Vmpl1) {
-            Ok((ca_va, vmsa_va)) => unsafe {
-                let vmsa: *mut Vmsa = vmsa_va.as_mut_ptr();
-                let ca: *mut Ca = ca_va.as_mut_ptr();
-
-                if (*vmsa).guest_exitcode() == VMEXIT_VMGEXIT && (*ca).call_pending() == 1 {
-                    handle_request(vmsa);
-
-                    (*ca).set_call_pending(0);
-                }
-
-                unmap_guest_input(ca_va, vmsa_va);
-            },
+        match process_one_request(VMPL::Vmpl1) {
+            Ok(()) => (),
             Err(e) => prints!("{}", e),
-        }
-
+        };
         vc_run_vmpl(VMPL::Vmpl1);
     }
 }

--- a/src/util/util.rs
+++ b/src/util/util.rs
@@ -24,6 +24,18 @@ macro_rules! funcs {
     };
 }
 
+/// Generate get method for a given struct field and type
+#[macro_export]
+macro_rules! getter_func {
+    ($name: ident, $T: ty) => {
+        paste::paste! {
+            pub fn [<$name>](&self) -> $T {
+                self.$name
+            }
+        }
+    };
+}
+
 /// Statically check for a condition
 #[macro_export]
 macro_rules! STATIC_ASSERT {


### PR DESCRIPTION
During work on the attestation protocol I noticed that writing functions that map several memory areas into virtual memory is very cumbersome due to the need to unmap these areas in every error/exit condition throughout the function.

I introduced a MapGuard struct (similar to LockGuard) -- it implements the `Drop` trait which unmaps the area when the MapGuard goes out of scope. This allows mapping several areas with MapGuard and then returning whenever is needed (using `return` or `?`) from the middle of the function without manually unmapping all the still-mapped areas.

Example:

```rust
fn work() -> Result<()> {
  let map1 = MapGuard::new_private(gpa, size, true)?;
  // view the memory as a C struct
  let req: &MyRequestStruct = map1.as_object();

  let map2 = MapGuard::new_private(gpa2, size, true)?; // <--- an error here will cause map1 to unmap
  // view the memory as a slice of bytes with the correct size (the entire mapped area)
  let buf: &[u8] = map2.as_bytes();

  // read from the mapped memory
  if some_condition {
    return Err(...); // here both areas are unmapped
  }

  Ok(())
  // here both areas are unmapped
}
```

The second commit replaces one pair of `pgtable_map_pages_private()/pgtable_unmap_pages()` with MapGuard. There are other opportunities to use it in linux-svsm, but:
1. I wanted to get feedback first
2. Changes in svsm_request will conflict with #38 , so I prefer to wait.

