### PR TITLE
Add openssl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/openssl"]
+	path = external/openssl
+	url = https://github.com/openssl/openssl.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +39,7 @@ dependencies = [
 name = "linux_svsm"
 version = "0.1.0"
 dependencies = [
+ "cty",
  "lazy_static",
  "memchr",
  "memoffset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ memoffset = "0.6"
 paste = "1.0"
 memchr = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
+cty = "0.2.2"
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,11 @@ LDS_FLAGS	+= -DSVSM_GPA="$(SVSM_GPA)"
 LDS_FLAGS	+= -DSVSM_MEM="$(SVSM_MEM)"
 
 EXT_LIBS := external/libcrt/libcrt.a
+EXT_LIBS += external/openssl/libcrypto.a
 
-.PHONY: all doc prereq clean clean_all superclean libcrt
+.PHONY: all doc prereq clean clean_all superclean libcrt libcrypto
 
-all: .prereq libcrt svsm.bin
+all: .prereq libcrt libcrypto svsm.bin
 
 doc: .prereq
 	cargo doc --open
@@ -44,6 +45,11 @@ external/libcrt/libcrt.a: libcrt
 
 libcrt:
 	$(MAKE) -C external/libcrt
+
+external/openssl/libcrypto.a: libcrypto
+
+libcrypto: external/openssl/Makefile libcrt
+	$(MAKE) -C external/openssl -j$$(nproc)
 
 svsm.bin: svsm.bin.elf
 	objcopy -g -O binary $< $@
@@ -140,6 +146,7 @@ clean:
 
 clean_all: clean
 	$(MAKE) -C external/libcrt clean
+	$(MAKE) -C external/openssl clean
 
 superclean: clean_all
 	rm -f .prereq

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ doc: .prereq
 svsm.bin: svsm.bin.elf
 	objcopy -g -O binary $< $@
 
+# "-Wl,-u,malloc" prevents the linker from removing the wrapper.rs symbols
 svsm.bin.elf: $(OBJS) src/start/svsm.lds
-	$(GCC) $(LD_FLAGS) -o $@ $(OBJS)
+	$(GCC) $(LD_FLAGS) -o $@ $(OBJS) -Wl,-u,malloc
 
 %.a: src/*.rs src/cpu/*.rs src/mem/*.rs src/protocols/*.rs src/util/*.rs
 	@xargo build --features $(FEATURES)

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,62 @@ prereq: .prereq
 	cargo install bootimage
 	touch .prereq
 
+external/openssl/Makefile:
+	git submodule update --init
+	(cd external/openssl && git checkout OpenSSL_1_1_1q  && \
+		./Configure \
+			--config=../openssl_svsm.conf \
+			SVSM \
+			no-afalgeng \
+			no-async \
+			no-autoerrinit \
+			no-autoload-config \
+			no-bf \
+			no-blake2 \
+			no-capieng \
+			no-cast \
+			no-chacha \
+			no-cms \
+			no-ct \
+			no-deprecated \
+			no-des \
+			no-dgram \
+			no-dsa \
+			no-dynamic-engine \
+			no-ec2m \
+			no-engine \
+			no-err \
+			no-filenames \
+			no-gost \
+			no-hw \
+			no-idea \
+			no-md4 \
+			no-mdc2 \
+			no-pic \
+			no-ocb \
+			no-poly1305 \
+			no-posix-io \
+			no-rc2 \
+			no-rc4 \
+			no-rfc3779 \
+			no-rmd160 \
+			no-scrypt \
+			no-seed \
+			no-sock \
+			no-srp \
+			no-ssl \
+			no-stdio \
+			no-threads \
+			no-ts \
+			no-whirlpool \
+			no-shared \
+			no-sse2 \
+			no-ui-console \
+			no-asm \
+			--with-rand-seed=none \
+			-I../libcrt/include \
+			-Wl,rpath=../libcrt -lcrt )
+
 clean:
 	@xargo clean 
 	rm -f svsm.bin svsm.bin.elf $(OBJS)

--- a/external/libcrt/Makefile
+++ b/external/libcrt/Makefile
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+
+CFLAGS  = -I./include -O3 -nostdinc -nostdlib
+CFLAGS += -m64 -march=x86-64 -mno-sse2 -fPIE
+CFLAGS += -fno-stack-protector
+CFLAGS += -ffreestanding
+
+CC := gcc
+
+PREFIX := /usr/local/
+
+# Functions we stub out
+OBJS := src/stub.o
+
+# ctype
+OBJS += $(addprefix src/ctype/, \
+				isdigit.o \
+				islower.o \
+				isspace.o \
+				isupper.o \
+				tolower.o \
+				toupper.o \
+				)
+# exit
+OBJS += src/exit/assert.o
+
+# prng
+OBJS += src/prng/rand.o
+
+# setjmp
+OBJS += $(addprefix src/setjmp/x86_64/, \
+				longjmp.o \
+				setjmp.o \
+				)
+# stdio
+OBJS += $(addprefix src/stdio/, \
+				asprintf.o \
+				fprintf.o \
+				printf.o \
+				printf_wrapper.o \
+				snprintf.o \
+				sprintf.o \
+				vasprintf.o \
+				vsnprintf.o \
+				vsprintf.o \
+				)
+# stdlib
+OBJS += $(addprefix src/stdlib/, \
+				atoi.o \
+				qsort.o \
+				qsort_nr.o \
+				)
+# string
+OBJS += $(addprefix src/string/, \
+				memchr.o \
+				memcmp.o \
+				memcpy.o \
+				memmove.o \
+				memrchr.o \
+				memset.o \
+				stpcpy.o \
+				stpncpy.o \
+				strcasecmp.o \
+				strcat.o \
+				strchr.o \
+				strchrnul.o \
+				strcmp.o \
+				strcspn.o \
+				strcpy.o \
+				strdup.o \
+				strlen.o \
+				strncasecmp.o \
+				strncat.o \
+				strncmp.o \
+				strncpy.o \
+				strrchr.o \
+				strspn.o \
+				strstr.o \
+				)
+# time
+OBJS += $(addprefix src/time/, \
+				__secs_to_tm.o \
+				gmtime_r.o \
+				time.o \
+				)
+
+all: libcrt.a
+
+libcrt.a: $(OBJS)
+	ar rcs $@ $(OBJS)
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.o : %.s
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f libcrt.a
+	rm -f $(OBJS)

--- a/external/libcrt/README.md
+++ b/external/libcrt/README.md
@@ -1,0 +1,17 @@
+# C Run-Time (CRT) Library
+
+The libcrt is a subset of the [musl libc](https://musl.libc.org/). It provides
+only the libc functions required to build the SVSM external dependencies.
+
+# Code organization
+
+The `libcrt.h` header centralizes all definitions, the other header files are
+just a proxy for the `libcrt.h`. Hence, when we include a header in a source
+file, we are actually including the entire `libcrt.h`. That allow us to build
+openssl without having to patch it to include missing headers.
+
+In order to build the SVSM dependencies, some functions are required to be
+defined at build time, however, not all of them are executed at runtime. For
+those cases, we just stub out the function by printing a message and returning
+an error. For easy tracking, all the function we stub out can be found in
+`src/stub.c`.

--- a/external/libcrt/include/assert.h
+++ b/external/libcrt/include/assert.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/atomic.h
+++ b/external/libcrt/include/atomic.h
@@ -1,0 +1,335 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef _ATOMIC_H
+#define _ATOMIC_H
+
+#include <stdint.h>
+
+#include <bits/atomic_arch.h>
+
+#ifdef a_ll
+
+#ifndef a_pre_llsc
+#define a_pre_llsc()
+#endif
+
+#ifndef a_post_llsc
+#define a_post_llsc()
+#endif
+
+#ifndef a_cas
+#define a_cas a_cas
+static inline int a_cas(volatile int *p, int t, int s)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (old==t && !a_sc(p, s));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_swap
+#define a_swap a_swap
+static inline int a_swap(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_fetch_add
+#define a_fetch_add a_fetch_add
+static inline int a_fetch_add(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, (unsigned)old + v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_fetch_and
+#define a_fetch_and a_fetch_and
+static inline int a_fetch_and(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, old & v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_fetch_or
+#define a_fetch_or a_fetch_or
+static inline int a_fetch_or(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, old | v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#endif
+
+#ifdef a_ll_p
+
+#ifndef a_cas_p
+#define a_cas_p a_cas_p
+static inline void *a_cas_p(volatile void *p, void *t, void *s)
+{
+	void *old;
+	a_pre_llsc();
+	do old = a_ll_p(p);
+	while (old==t && !a_sc_p(p, s));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#endif
+
+#ifndef a_cas
+#error missing definition of a_cas
+#endif
+
+#ifndef a_swap
+#define a_swap a_swap
+static inline int a_swap(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, v) != old);
+	return old;
+}
+#endif
+
+#ifndef a_fetch_add
+#define a_fetch_add a_fetch_add
+static inline int a_fetch_add(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, (unsigned)old+v) != old);
+	return old;
+}
+#endif
+
+#ifndef a_fetch_and
+#define a_fetch_and a_fetch_and
+static inline int a_fetch_and(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, old&v) != old);
+	return old;
+}
+#endif
+#ifndef a_fetch_or
+#define a_fetch_or a_fetch_or
+static inline int a_fetch_or(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, old|v) != old);
+	return old;
+}
+#endif
+
+#ifndef a_and
+#define a_and a_and
+static inline void a_and(volatile int *p, int v)
+{
+	a_fetch_and(p, v);
+}
+#endif
+
+#ifndef a_or
+#define a_or a_or
+static inline void a_or(volatile int *p, int v)
+{
+	a_fetch_or(p, v);
+}
+#endif
+
+#ifndef a_inc
+#define a_inc a_inc
+static inline void a_inc(volatile int *p)
+{
+	a_fetch_add(p, 1);
+}
+#endif
+
+#ifndef a_dec
+#define a_dec a_dec
+static inline void a_dec(volatile int *p)
+{
+	a_fetch_add(p, -1);
+}
+#endif
+
+#ifndef a_store
+#define a_store a_store
+static inline void a_store(volatile int *p, int v)
+{
+#ifdef a_barrier
+	a_barrier();
+	*p = v;
+	a_barrier();
+#else
+	a_swap(p, v);
+#endif
+}
+#endif
+
+#ifndef a_barrier
+#define a_barrier a_barrier
+static void a_barrier()
+{
+	volatile int tmp = 0;
+	a_cas(&tmp, 0, 0);
+}
+#endif
+
+#ifndef a_spin
+#define a_spin a_barrier
+#endif
+
+#ifndef a_and_64
+#define a_and_64 a_and_64
+static inline void a_and_64(volatile uint64_t *p, uint64_t v)
+{
+	union { uint64_t v; uint32_t r[2]; } u = { v };
+	if (u.r[0]+1) a_and((int *)p, u.r[0]);
+	if (u.r[1]+1) a_and((int *)p+1, u.r[1]);
+}
+#endif
+
+#ifndef a_or_64
+#define a_or_64 a_or_64
+static inline void a_or_64(volatile uint64_t *p, uint64_t v)
+{
+	union { uint64_t v; uint32_t r[2]; } u = { v };
+	if (u.r[0]) a_or((int *)p, u.r[0]);
+	if (u.r[1]) a_or((int *)p+1, u.r[1]);
+}
+#endif
+
+#ifndef a_cas_p
+typedef char a_cas_p_undefined_but_pointer_not_32bit[-sizeof(char) == 0xffffffff ? 1 : -1];
+#define a_cas_p a_cas_p
+static inline void *a_cas_p(volatile void *p, void *t, void *s)
+{
+	return (void *)a_cas((volatile int *)p, (int)t, (int)s);
+}
+#endif
+
+#ifndef a_or_l
+#define a_or_l a_or_l
+static inline void a_or_l(volatile void *p, long v)
+{
+	if (sizeof(long) == sizeof(int)) a_or(p, v);
+	else a_or_64(p, v);
+}
+#endif
+
+#ifndef a_crash
+#define a_crash a_crash
+static inline void a_crash()
+{
+	*(volatile char *)0=0;
+}
+#endif
+
+#ifndef a_ctz_32
+#define a_ctz_32 a_ctz_32
+static inline int a_ctz_32(uint32_t x)
+{
+#ifdef a_clz_32
+	return 31-a_clz_32(x&-x);
+#else
+	static const char debruijn32[32] = {
+		0, 1, 23, 2, 29, 24, 19, 3, 30, 27, 25, 11, 20, 8, 4, 13,
+		31, 22, 28, 18, 26, 10, 7, 12, 21, 17, 9, 6, 16, 5, 15, 14
+	};
+	return debruijn32[(x&-x)*0x076be629 >> 27];
+#endif
+}
+#endif
+
+#ifndef a_ctz_64
+#define a_ctz_64 a_ctz_64
+static inline int a_ctz_64(uint64_t x)
+{
+	static const char debruijn64[64] = {
+		0, 1, 2, 53, 3, 7, 54, 27, 4, 38, 41, 8, 34, 55, 48, 28,
+		62, 5, 39, 46, 44, 42, 22, 9, 24, 35, 59, 56, 49, 18, 29, 11,
+		63, 52, 6, 26, 37, 40, 33, 47, 61, 45, 43, 21, 23, 58, 17, 10,
+		51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12
+	};
+	if (sizeof(long) < 8) {
+		uint32_t y = x;
+		if (!y) {
+			y = x>>32;
+			return 32 + a_ctz_32(y);
+		}
+		return a_ctz_32(y);
+	}
+	return debruijn64[(x&-x)*0x022fdd63cc95386dull >> 58];
+}
+#endif
+
+static inline int a_ctz_l(unsigned long x)
+{
+	return (sizeof(long) < 8) ? a_ctz_32(x) : a_ctz_64(x);
+}
+
+#ifndef a_clz_64
+#define a_clz_64 a_clz_64
+static inline int a_clz_64(uint64_t x)
+{
+#ifdef a_clz_32
+	if (x>>32)
+		return a_clz_32(x>>32);
+	return a_clz_32(x) + 32;
+#else
+	uint32_t y;
+	int r;
+	if (x>>32) y=x>>32, r=0; else y=x, r=32;
+	if (y>>16) y>>=16; else r |= 16;
+	if (y>>8) y>>=8; else r |= 8;
+	if (y>>4) y>>=4; else r |= 4;
+	if (y>>2) y>>=2; else r |= 2;
+	return r | !(y>>1);
+#endif
+}
+#endif
+
+#ifndef a_clz_32
+#define a_clz_32 a_clz_32
+static inline int a_clz_32(uint32_t x)
+{
+	x >>= 1;
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
+	x++;
+	return 31-a_ctz_32(x);
+}
+#endif
+
+#endif

--- a/external/libcrt/include/bits/alltypes.h
+++ b/external/libcrt/include/bits/alltypes.h
@@ -1,0 +1,417 @@
+/* SPDX-License-Identifier: MIT */
+
+#define _Addr long
+#define _Int64 long
+#define _Reg long
+
+#define __BYTE_ORDER 1234
+#define __LONG_MAX 0x7fffffffffffffffL
+
+#ifndef __cplusplus
+#if defined(__NEED_wchar_t) && !defined(__DEFINED_wchar_t)
+typedef int wchar_t;
+#define __DEFINED_wchar_t
+#endif
+
+#endif
+
+#if defined(__FLT_EVAL_METHOD__) && __FLT_EVAL_METHOD__ == 2
+#if defined(__NEED_float_t) && !defined(__DEFINED_float_t)
+typedef long double float_t;
+#define __DEFINED_float_t
+#endif
+
+#if defined(__NEED_double_t) && !defined(__DEFINED_double_t)
+typedef long double double_t;
+#define __DEFINED_double_t
+#endif
+
+#else
+#if defined(__NEED_float_t) && !defined(__DEFINED_float_t)
+typedef float float_t;
+#define __DEFINED_float_t
+#endif
+
+#if defined(__NEED_double_t) && !defined(__DEFINED_double_t)
+typedef double double_t;
+#define __DEFINED_double_t
+#endif
+
+#endif
+
+#if defined(__NEED_max_align_t) && !defined(__DEFINED_max_align_t)
+typedef struct { long long __ll; long double __ld; } max_align_t;
+#define __DEFINED_max_align_t
+#endif
+
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+#define __USE_TIME_BITS64 1
+
+#if defined(__NEED_size_t) && !defined(__DEFINED_size_t)
+typedef unsigned _Addr size_t;
+#define __DEFINED_size_t
+#endif
+
+#if defined(__NEED_uintptr_t) && !defined(__DEFINED_uintptr_t)
+typedef unsigned _Addr uintptr_t;
+#define __DEFINED_uintptr_t
+#endif
+
+#if defined(__NEED_ptrdiff_t) && !defined(__DEFINED_ptrdiff_t)
+typedef _Addr ptrdiff_t;
+#define __DEFINED_ptrdiff_t
+#endif
+
+#if defined(__NEED_ssize_t) && !defined(__DEFINED_ssize_t)
+typedef _Addr ssize_t;
+#define __DEFINED_ssize_t
+#endif
+
+#if defined(__NEED_intptr_t) && !defined(__DEFINED_intptr_t)
+typedef _Addr intptr_t;
+#define __DEFINED_intptr_t
+#endif
+
+#if defined(__NEED_regoff_t) && !defined(__DEFINED_regoff_t)
+typedef _Addr regoff_t;
+#define __DEFINED_regoff_t
+#endif
+
+#if defined(__NEED_register_t) && !defined(__DEFINED_register_t)
+typedef _Reg register_t;
+#define __DEFINED_register_t
+#endif
+
+#if defined(__NEED_time_t) && !defined(__DEFINED_time_t)
+typedef _Int64 time_t;
+#define __DEFINED_time_t
+#endif
+
+#if defined(__NEED_suseconds_t) && !defined(__DEFINED_suseconds_t)
+typedef _Int64 suseconds_t;
+#define __DEFINED_suseconds_t
+#endif
+
+
+#if defined(__NEED_int8_t) && !defined(__DEFINED_int8_t)
+typedef signed char     int8_t;
+#define __DEFINED_int8_t
+#endif
+
+#if defined(__NEED_int16_t) && !defined(__DEFINED_int16_t)
+typedef signed short    int16_t;
+#define __DEFINED_int16_t
+#endif
+
+#if defined(__NEED_int32_t) && !defined(__DEFINED_int32_t)
+typedef signed int      int32_t;
+#define __DEFINED_int32_t
+#endif
+
+#if defined(__NEED_int64_t) && !defined(__DEFINED_int64_t)
+typedef signed _Int64   int64_t;
+#define __DEFINED_int64_t
+#endif
+
+#if defined(__NEED_intmax_t) && !defined(__DEFINED_intmax_t)
+typedef signed _Int64   intmax_t;
+#define __DEFINED_intmax_t
+#endif
+
+#if defined(__NEED_uint8_t) && !defined(__DEFINED_uint8_t)
+typedef unsigned char   uint8_t;
+#define __DEFINED_uint8_t
+#endif
+
+#if defined(__NEED_uint16_t) && !defined(__DEFINED_uint16_t)
+typedef unsigned short  uint16_t;
+#define __DEFINED_uint16_t
+#endif
+
+#if defined(__NEED_uint32_t) && !defined(__DEFINED_uint32_t)
+typedef unsigned int    uint32_t;
+#define __DEFINED_uint32_t
+#endif
+
+#if defined(__NEED_uint64_t) && !defined(__DEFINED_uint64_t)
+typedef unsigned _Int64 uint64_t;
+#define __DEFINED_uint64_t
+#endif
+
+#if defined(__NEED_u_int64_t) && !defined(__DEFINED_u_int64_t)
+typedef unsigned _Int64 u_int64_t;
+#define __DEFINED_u_int64_t
+#endif
+
+#if defined(__NEED_uintmax_t) && !defined(__DEFINED_uintmax_t)
+typedef unsigned _Int64 uintmax_t;
+#define __DEFINED_uintmax_t
+#endif
+
+
+#if defined(__NEED_mode_t) && !defined(__DEFINED_mode_t)
+typedef unsigned mode_t;
+#define __DEFINED_mode_t
+#endif
+
+#if defined(__NEED_nlink_t) && !defined(__DEFINED_nlink_t)
+typedef unsigned _Reg nlink_t;
+#define __DEFINED_nlink_t
+#endif
+
+#if defined(__NEED_off_t) && !defined(__DEFINED_off_t)
+typedef _Int64 off_t;
+#define __DEFINED_off_t
+#endif
+
+#if defined(__NEED_ino_t) && !defined(__DEFINED_ino_t)
+typedef unsigned _Int64 ino_t;
+#define __DEFINED_ino_t
+#endif
+
+#if defined(__NEED_dev_t) && !defined(__DEFINED_dev_t)
+typedef unsigned _Int64 dev_t;
+#define __DEFINED_dev_t
+#endif
+
+#if defined(__NEED_blksize_t) && !defined(__DEFINED_blksize_t)
+typedef long blksize_t;
+#define __DEFINED_blksize_t
+#endif
+
+#if defined(__NEED_blkcnt_t) && !defined(__DEFINED_blkcnt_t)
+typedef _Int64 blkcnt_t;
+#define __DEFINED_blkcnt_t
+#endif
+
+#if defined(__NEED_fsblkcnt_t) && !defined(__DEFINED_fsblkcnt_t)
+typedef unsigned _Int64 fsblkcnt_t;
+#define __DEFINED_fsblkcnt_t
+#endif
+
+#if defined(__NEED_fsfilcnt_t) && !defined(__DEFINED_fsfilcnt_t)
+typedef unsigned _Int64 fsfilcnt_t;
+#define __DEFINED_fsfilcnt_t
+#endif
+
+
+#if defined(__NEED_wint_t) && !defined(__DEFINED_wint_t)
+typedef unsigned wint_t;
+#define __DEFINED_wint_t
+#endif
+
+#if defined(__NEED_wctype_t) && !defined(__DEFINED_wctype_t)
+typedef unsigned long wctype_t;
+#define __DEFINED_wctype_t
+#endif
+
+
+#if defined(__NEED_timer_t) && !defined(__DEFINED_timer_t)
+typedef void * timer_t;
+#define __DEFINED_timer_t
+#endif
+
+#if defined(__NEED_clockid_t) && !defined(__DEFINED_clockid_t)
+typedef int clockid_t;
+#define __DEFINED_clockid_t
+#endif
+
+#if defined(__NEED_clock_t) && !defined(__DEFINED_clock_t)
+typedef long clock_t;
+#define __DEFINED_clock_t
+#endif
+
+#if defined(__NEED_struct_timeval) && !defined(__DEFINED_struct_timeval)
+struct timeval { time_t tv_sec; suseconds_t tv_usec; };
+#define __DEFINED_struct_timeval
+#endif
+
+#if defined(__NEED_struct_timespec) && !defined(__DEFINED_struct_timespec)
+struct timespec { time_t tv_sec; int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER==4321); long tv_nsec; int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER!=4321); };
+#define __DEFINED_struct_timespec
+#endif
+
+
+#if defined(__NEED_pid_t) && !defined(__DEFINED_pid_t)
+typedef int pid_t;
+#define __DEFINED_pid_t
+#endif
+
+#if defined(__NEED_id_t) && !defined(__DEFINED_id_t)
+typedef unsigned id_t;
+#define __DEFINED_id_t
+#endif
+
+#if defined(__NEED_uid_t) && !defined(__DEFINED_uid_t)
+typedef unsigned uid_t;
+#define __DEFINED_uid_t
+#endif
+
+#if defined(__NEED_gid_t) && !defined(__DEFINED_gid_t)
+typedef unsigned gid_t;
+#define __DEFINED_gid_t
+#endif
+
+#if defined(__NEED_key_t) && !defined(__DEFINED_key_t)
+typedef int key_t;
+#define __DEFINED_key_t
+#endif
+
+#if defined(__NEED_useconds_t) && !defined(__DEFINED_useconds_t)
+typedef unsigned useconds_t;
+#define __DEFINED_useconds_t
+#endif
+
+
+#ifdef __cplusplus
+#if defined(__NEED_pthread_t) && !defined(__DEFINED_pthread_t)
+typedef unsigned long pthread_t;
+#define __DEFINED_pthread_t
+#endif
+
+#else
+#if defined(__NEED_pthread_t) && !defined(__DEFINED_pthread_t)
+typedef struct __pthread * pthread_t;
+#define __DEFINED_pthread_t
+#endif
+
+#endif
+#if defined(__NEED_pthread_once_t) && !defined(__DEFINED_pthread_once_t)
+typedef int pthread_once_t;
+#define __DEFINED_pthread_once_t
+#endif
+
+#if defined(__NEED_pthread_key_t) && !defined(__DEFINED_pthread_key_t)
+typedef unsigned pthread_key_t;
+#define __DEFINED_pthread_key_t
+#endif
+
+#if defined(__NEED_pthread_spinlock_t) && !defined(__DEFINED_pthread_spinlock_t)
+typedef int pthread_spinlock_t;
+#define __DEFINED_pthread_spinlock_t
+#endif
+
+#if defined(__NEED_pthread_mutexattr_t) && !defined(__DEFINED_pthread_mutexattr_t)
+typedef struct { unsigned __attr; } pthread_mutexattr_t;
+#define __DEFINED_pthread_mutexattr_t
+#endif
+
+#if defined(__NEED_pthread_condattr_t) && !defined(__DEFINED_pthread_condattr_t)
+typedef struct { unsigned __attr; } pthread_condattr_t;
+#define __DEFINED_pthread_condattr_t
+#endif
+
+#if defined(__NEED_pthread_barrierattr_t) && !defined(__DEFINED_pthread_barrierattr_t)
+typedef struct { unsigned __attr; } pthread_barrierattr_t;
+#define __DEFINED_pthread_barrierattr_t
+#endif
+
+#if defined(__NEED_pthread_rwlockattr_t) && !defined(__DEFINED_pthread_rwlockattr_t)
+typedef struct { unsigned __attr[2]; } pthread_rwlockattr_t;
+#define __DEFINED_pthread_rwlockattr_t
+#endif
+
+
+#if defined(__NEED_struct__IO_FILE) && !defined(__DEFINED_struct__IO_FILE)
+struct _IO_FILE { char __x; };
+#define __DEFINED_struct__IO_FILE
+#endif
+
+#if defined(__NEED_FILE) && !defined(__DEFINED_FILE)
+typedef struct _IO_FILE FILE;
+#define __DEFINED_FILE
+#endif
+
+
+#if defined(__NEED_va_list) && !defined(__DEFINED_va_list)
+typedef __builtin_va_list va_list;
+#define __DEFINED_va_list
+#endif
+
+#if defined(__NEED___isoc_va_list) && !defined(__DEFINED___isoc_va_list)
+typedef __builtin_va_list __isoc_va_list;
+#define __DEFINED___isoc_va_list
+#endif
+
+
+#if defined(__NEED_mbstate_t) && !defined(__DEFINED_mbstate_t)
+typedef struct __mbstate_t { unsigned __opaque1, __opaque2; } mbstate_t;
+#define __DEFINED_mbstate_t
+#endif
+
+
+#if defined(__NEED_locale_t) && !defined(__DEFINED_locale_t)
+typedef struct __locale_struct * locale_t;
+#define __DEFINED_locale_t
+#endif
+
+
+#if defined(__NEED_sigset_t) && !defined(__DEFINED_sigset_t)
+typedef struct __sigset_t { unsigned long __bits[128/sizeof(long)]; } sigset_t;
+#define __DEFINED_sigset_t
+#endif
+
+
+#if defined(__NEED_struct_iovec) && !defined(__DEFINED_struct_iovec)
+struct iovec { void *iov_base; size_t iov_len; };
+#define __DEFINED_struct_iovec
+#endif
+
+
+#if defined(__NEED_struct_winsize) && !defined(__DEFINED_struct_winsize)
+struct winsize { unsigned short ws_row, ws_col, ws_xpixel, ws_ypixel; };
+#define __DEFINED_struct_winsize
+#endif
+
+
+#if defined(__NEED_socklen_t) && !defined(__DEFINED_socklen_t)
+typedef unsigned socklen_t;
+#define __DEFINED_socklen_t
+#endif
+
+#if defined(__NEED_sa_family_t) && !defined(__DEFINED_sa_family_t)
+typedef unsigned short sa_family_t;
+#define __DEFINED_sa_family_t
+#endif
+
+
+#if defined(__NEED_pthread_attr_t) && !defined(__DEFINED_pthread_attr_t)
+typedef struct { union { int __i[sizeof(long)==8?14:9]; volatile int __vi[sizeof(long)==8?14:9]; unsigned long __s[sizeof(long)==8?7:9]; } __u; } pthread_attr_t;
+#define __DEFINED_pthread_attr_t
+#endif
+
+#if defined(__NEED_pthread_mutex_t) && !defined(__DEFINED_pthread_mutex_t)
+typedef struct { union { int __i[sizeof(long)==8?10:6]; volatile int __vi[sizeof(long)==8?10:6]; volatile void *volatile __p[sizeof(long)==8?5:6]; } __u; } pthread_mutex_t;
+#define __DEFINED_pthread_mutex_t
+#endif
+
+#if defined(__NEED_mtx_t) && !defined(__DEFINED_mtx_t)
+typedef struct { union { int __i[sizeof(long)==8?10:6]; volatile int __vi[sizeof(long)==8?10:6]; volatile void *volatile __p[sizeof(long)==8?5:6]; } __u; } mtx_t;
+#define __DEFINED_mtx_t
+#endif
+
+#if defined(__NEED_pthread_cond_t) && !defined(__DEFINED_pthread_cond_t)
+typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12*sizeof(int)/sizeof(void*)]; } __u; } pthread_cond_t;
+#define __DEFINED_pthread_cond_t
+#endif
+
+#if defined(__NEED_cnd_t) && !defined(__DEFINED_cnd_t)
+typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12*sizeof(int)/sizeof(void*)]; } __u; } cnd_t;
+#define __DEFINED_cnd_t
+#endif
+
+#if defined(__NEED_pthread_rwlock_t) && !defined(__DEFINED_pthread_rwlock_t)
+typedef struct { union { int __i[sizeof(long)==8?14:8]; volatile int __vi[sizeof(long)==8?14:8]; void *__p[sizeof(long)==8?7:8]; } __u; } pthread_rwlock_t;
+#define __DEFINED_pthread_rwlock_t
+#endif
+
+#if defined(__NEED_pthread_barrier_t) && !defined(__DEFINED_pthread_barrier_t)
+typedef struct { union { int __i[sizeof(long)==8?8:5]; volatile int __vi[sizeof(long)==8?8:5]; void *__p[sizeof(long)==8?4:5]; } __u; } pthread_barrier_t;
+#define __DEFINED_pthread_barrier_t
+#endif
+
+
+#undef _Addr
+#undef _Int64
+#undef _Reg

--- a/external/libcrt/include/bits/atomic_arch.h
+++ b/external/libcrt/include/bits/atomic_arch.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: MIT */
+
+#define a_cas a_cas
+static inline int a_cas(volatile int *p, int t, int s)
+{
+	__asm__ __volatile__ (
+		"lock ; cmpxchg %3, %1"
+		: "=a"(t), "=m"(*p) : "a"(t), "r"(s) : "memory" );
+	return t;
+}
+
+#define a_cas_p a_cas_p
+static inline void *a_cas_p(volatile void *p, void *t, void *s)
+{
+	__asm__( "lock ; cmpxchg %3, %1"
+		: "=a"(t), "=m"(*(void *volatile *)p)
+		: "a"(t), "r"(s) : "memory" );
+	return t;
+}
+
+#define a_swap a_swap
+static inline int a_swap(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"xchg %0, %1"
+		: "=r"(v), "=m"(*p) : "0"(v) : "memory" );
+	return v;
+}
+
+#define a_fetch_add a_fetch_add
+static inline int a_fetch_add(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"lock ; xadd %0, %1"
+		: "=r"(v), "=m"(*p) : "0"(v) : "memory" );
+	return v;
+}
+
+#define a_and a_and
+static inline void a_and(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"lock ; and %1, %0"
+		: "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_or a_or
+static inline void a_or(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"lock ; or %1, %0"
+		: "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_and_64 a_and_64
+static inline void a_and_64(volatile uint64_t *p, uint64_t v)
+{
+	__asm__ __volatile(
+		"lock ; and %1, %0"
+		 : "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_or_64 a_or_64
+static inline void a_or_64(volatile uint64_t *p, uint64_t v)
+{
+	__asm__ __volatile__(
+		"lock ; or %1, %0"
+		 : "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_inc a_inc
+static inline void a_inc(volatile int *p)
+{
+	__asm__ __volatile__(
+		"lock ; incl %0"
+		: "=m"(*p) : "m"(*p) : "memory" );
+}
+
+#define a_dec a_dec
+static inline void a_dec(volatile int *p)
+{
+	__asm__ __volatile__(
+		"lock ; decl %0"
+		: "=m"(*p) : "m"(*p) : "memory" );
+}
+
+#define a_store a_store
+static inline void a_store(volatile int *p, int x)
+{
+	__asm__ __volatile__(
+		"mov %1, %0 ; lock ; orl $0,(%%rsp)"
+		: "=m"(*p) : "r"(x) : "memory" );
+}
+
+#define a_barrier a_barrier
+static inline void a_barrier()
+{
+	__asm__ __volatile__( "" : : : "memory" );
+}
+
+#define a_spin a_spin
+static inline void a_spin()
+{
+	__asm__ __volatile__( "pause" : : : "memory" );
+}
+
+#define a_crash a_crash
+static inline void a_crash()
+{
+	__asm__ __volatile__( "hlt" : : : "memory" );
+}
+
+#define a_ctz_64 a_ctz_64
+static inline int a_ctz_64(uint64_t x)
+{
+	__asm__( "bsf %1,%0" : "=r"(x) : "r"(x) );
+	return x;
+}
+
+#define a_clz_64 a_clz_64
+static inline int a_clz_64(uint64_t x)
+{
+	__asm__( "bsr %1,%0 ; xor $63,%0" : "=r"(x) : "r"(x) );
+	return x;
+}

--- a/external/libcrt/include/ctype.h
+++ b/external/libcrt/include/ctype.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/dirent.h
+++ b/external/libcrt/include/dirent.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/endian.h
+++ b/external/libcrt/include/endian.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/errno.h
+++ b/external/libcrt/include/errno.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/fcntl.h
+++ b/external/libcrt/include/fcntl.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/inttypes.h
+++ b/external/libcrt/include/inttypes.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/libcrt.h
+++ b/external/libcrt/include/libcrt.h
@@ -1,0 +1,383 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef __LIBCRT_H__
+#define __LIBCRT_H__
+
+// The SVSM guids are expected to be the last bytes of the svsm.bin file. When
+// we set the external dependencies symbols to be hidden, we prevent them from
+// being preempted. Otherwise, the SVSM guids will not be the last bytes of the
+// svsm.bin.
+#if defined(__pie__)
+#pragma GCC visibility push (hidden)
+#endif
+
+// Openssl big number operation (bn_op). Ensure it is defined for all SVSM
+// external dependency that requires openssl crypto functions.
+#define SIXTY_FOUR_BIT_LONG
+
+// features.h
+
+#define _Noreturn __attribute__((__noreturn__))
+
+#define weak __attribute__((__weak__))
+#define hidden __attribute__((__visibility__("hidden")))
+#define weak_alias(old, new) \
+        extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
+
+// All types required
+
+#define __NEED_va_list
+
+#define __NEED_int8_t
+#define __NEED_int16_t
+#define __NEED_int32_t
+#define __NEED_int64_t
+
+#define __NEED_uint8_t
+#define __NEED_uint16_t
+#define __NEED_uint32_t
+#define __NEED_uint64_t
+
+#define __NEED_intptr_t
+#define __NEED_uintptr_t
+#define __NEED_size_t
+#define __NEED_ssize_t
+#define __NEED_ptrdiff_t
+#define __NEED_wchar_t
+
+#define __NEED_intmax_t
+#define __NEED_uintmax_t
+
+#define __NEED_time_t
+#define __NEED_clock_t
+#define __NEED_clockid_t
+#define __NEED_struct_timespec
+
+#define __NEED_pid_t
+#define __NEED_FILE
+#define __NEED_struct__IO_FILE
+
+#define __NEED_dev_t
+#define __NEED_ino_t
+#define __NEED_mode_t
+#define __NEED_nlink_t
+#define __NEED_uid_t
+#define __NEED_gid_t
+#define __NEED_off_t
+#define __NEED_blksize_t
+#define __NEED_blkcnt_t
+
+#include <bits/alltypes.h>
+
+// errno.h
+
+extern int errno;
+#define ENOMEM        12
+#define EINVAL        22
+#define EAFNOSUPPORT  47
+#define EOVERFLOW     75
+
+// stddef.h
+
+#ifndef NULL
+#define NULL  ((void *) 0)
+#endif
+
+#define offsetof(type, member) __builtin_offsetof(type, member)
+
+// stdbool.h
+
+#define true 1
+#define false 0
+#define bool _Bool
+
+// stdint.h
+
+#define INT8_MIN   (-1-0x7f)
+#define INT16_MIN  (-1-0x7fff)
+#define INT32_MIN  (-1-0x7fffffff)
+#define INT64_MIN  (-1-0x7fffffffffffffff)
+
+#define INT8_MAX   (0x7f)
+#define INT16_MAX  (0x7fff)
+#define INT32_MAX  (0x7fffffff)
+#define INT64_MAX  (0x7fffffffffffffff)
+
+#define UINT8_MAX  (0xff)
+#define UINT16_MAX (0xffff)
+#define UINT32_MAX (0xffffffffu)
+#define UINT64_MAX (0xffffffffffffffffu)
+
+// limits.h
+
+#define UCHAR_MAX  255
+#define SSIZE_MAX  0xFFFFFFFFFFFFFFFFU
+#define INT_MIN  (-1-0x7fffffff)
+#define INT_MAX  0x7fffffff
+#define LONG_MIN (-LONG_MAX-1)
+#define LONG_MAX __LONG_MAX
+#define UINT_MAX 0xffffffffU
+#define ULONG_MAX (2UL*LONG_MAX+1)
+#define CHAR_BIT 8
+
+// atomic.h
+
+// Check the atomic.h file for the atomic definitions. It is a busy file with
+// lots of inline functions and it also includes architecture dependent code.
+
+// stdarg.h
+
+#define va_start(v,l)   __builtin_va_start(v,l)
+#define va_end(v)       __builtin_va_end(v)
+#define va_arg(v,l)     __builtin_va_arg(v,l)
+#define va_copy(d,s)    __builtin_va_copy(d,s)
+
+// unistd.h
+
+#define STDERR_FILENO 2
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
+pid_t getpid(void);
+uid_t getuid(void);
+uid_t geteuid(void);
+gid_t getgid(void);
+gid_t getegid(void);
+int issetugid(void);
+
+// stdio.h
+
+#define EOF (-1)
+#define BUFSIZ  8192
+void setbuf(FILE *stream, char *buf);
+int printf(const char *restrict fmt, ...);
+int dprintf(int fd, const char *__restrict fmt, ...);
+int vdprintf(int fd, const char *restrict fmt, va_list ap);
+int puts(const char *s);
+int fprintf(FILE *restrict f, const char *restrict fmt, ...);
+int asprintf(char **s, const char *fmt, ...);
+int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...);
+int sprintf(char *restrict s, const char *restrict fmt, ...);
+int vasprintf(char **s, const char *fmt, va_list ap);
+int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap);
+int vsprintf(char *restrict s, const char *restrict fmt, va_list ap);
+
+int vprints(const char *format, va_list ap);
+int vsnprints(char *str, size_t size, const char *format, va_list ap);
+
+// Functions exported by the SVSM
+extern void serial_out(const char *s, int len);
+
+// stdlib.h
+
+// Functions exported by the SVSM
+extern void *malloc(size_t size);
+extern void *realloc(void *ptr, size_t size);
+extern void *calloc(size_t nmemb, size_t size);
+extern void free(void *ptr);
+extern _Noreturn void abort(void);
+
+int atoi(const char *s);
+int atexit(void (*func)(void));
+
+void qsort(void *, size_t, size_t,  int (*)(const void *, const void *));
+void qsort_r(void *, size_t, size_t, int (*)(const void *, const void *, void *), void *);
+void __qsort_r(void *, size_t, size_t, int (*)(const void *, const void *, void *), void *);
+
+char *getenv(const char *);
+
+int rand(void);
+void srand(unsigned s);
+
+// time.h
+
+struct tm {
+  int tm_sec;     /* seconds after the minute [0-60] */
+  int tm_min;     /* minutes after the hour [0-59] */
+  int tm_hour;    /* hours since midnight [0-23] */
+  int tm_mday;    /* day of the month [1-31] */
+  int tm_mon;     /* months since January [0-11] */
+  int tm_year;    /* years since 1900 */
+  int tm_wday;    /* days since Sunday [0-6] */
+  int tm_yday;    /* days since January 1 [0-365] */
+  int tm_isdst;   /* Daylight Savings Time flag */
+  long tm_gmtoff; /* offset from CUT in seconds */
+  char *tm_zone;  /* timezone abbreviation */
+};
+
+struct timeval {
+  long tv_sec;  /* time value, in seconds */
+  long tv_usec; /* time value, in microseconds */
+};
+
+time_t time(time_t *);
+struct tm *gmtime(const time_t *);
+struct tm *gmtime_r(const time_t *restrict t, struct tm *restrict tm);
+clock_t clock(void);
+int clock_gettime(clockid_t clk_id, struct timespec *tp);
+int gettimeofday(struct timeval *restrict tv, void *restrict tz);
+int __secs_to_tm(long long t, struct tm *tm);
+
+#define DECLARE_ARGS(val, low, high)	unsigned long low, high
+#define EAX_EDX_VAL(val, low, high)	((low) | (high) << 32)
+#define EAX_EDX_RET(val, low, high)	"=a" (low), "=d" (high)
+
+static inline unsigned long long rdtsc(void)
+{
+	DECLARE_ARGS(val, low, high);
+	asm volatile("rdtsc" : EAX_EDX_RET(val, low, high));
+	return EAX_EDX_VAL(val, low, high);
+}
+
+// inttypes.h
+
+#if UINTPTR_MAX == UINT64_MAX
+#define __PRI64  "l"
+#define __PRIPTR "l"
+#else
+#define __PRI64  "ll"
+#define __PRIPTR ""
+#endif
+
+#define PRIu8  "u"
+#define PRIu16 "u"
+#define PRIu32 "u"
+#define PRIu64 __PRI64 "u"
+
+// dirent.h
+
+typedef struct __dirstream DIR;
+
+struct dirent {
+    ino_t d_ino;
+    off_t d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+};
+
+DIR *opendir(const char *name);
+int closedir(DIR *name);
+struct dirent *readdir(DIR *name);
+
+typedef unsigned long __jmp_buf[8];
+
+typedef struct __jmp_buf_tag {
+	__jmp_buf __jb;
+	unsigned long __fl;
+	unsigned long __ss[128/sizeof(long)];
+} jmp_buf[1];
+
+#define __setjmp_attr __attribute__((__returns_twice__))
+
+// sys/stat.h
+
+#define S_IFDIR 0040000
+#define S_IFMT  0170000
+
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+
+/* copied from kernel definition, but with padding replaced
+ * by the corresponding correctly-sized userspace types. */
+struct stat {
+    dev_t st_dev;
+    ino_t st_ino;
+    nlink_t st_nlink;
+
+    mode_t st_mode;
+    uid_t st_uid;
+    gid_t st_gid;
+    unsigned int    __pad0;
+    dev_t st_rdev;
+    off_t st_size;
+    blksize_t st_blksize;
+    blkcnt_t st_blocks;
+
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    long __unused[3];
+};
+
+int stat(const char *__restrict path, struct stat *restrict buf);
+
+// string.h
+
+void *memset(void *, int, size_t);
+int memcmp(const void *, const void *, size_t);
+void *memcpy(void *restrict dest, const void *restrict src, size_t n);
+void *memchr(const void *src, int c, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
+void *memrchr(const void *m, int c, size_t n);
+void *__memrchr(const void *m, int c, size_t n);
+
+int strcmp(const char *, const char *);
+int strncasecmp(const char *, const char *, size_t);
+char *strchr(const char *, int);
+char *strrchr(const char *, int);
+unsigned long strtoul(const char *, char **, int);
+long strtol(const char *, char **, int);
+char *strerror(int);
+size_t strspn(const char *, const char *);
+size_t strcspn(const char *, const char *);
+
+char *strcpy(char *strDest, const char  *strSource);
+size_t strlen(const char *s);
+char *__strchrnul(const char *s, int c);
+char *__stpcpy(char *restrict d, const char *restrict s);
+char *__stpncpy(char *restrict d, const char *restrict s, size_t n);
+char *strstr(const char *h, const char *n);
+char *strdup(const char *s);
+char *strncpy(char *restrict d, const char *restrict s, size_t n);
+int strncmp(const char *_l, const char *_r, size_t n);
+int strcasecmp(const char *_l, const char *_r);
+char *strcat(char *restrict dest, const char *restrict src);
+char *strncat (char *__restrict, const char *__restrict, size_t);
+
+// ctype.h
+
+int isdigit(int c);
+int isspace(int c);
+int isupper(int c);
+int isascii(int c);
+int islower(int c);
+
+int tolower(int c);
+int toupper(int c);
+
+// stdio.h
+
+int printf(const char *, ...);
+int sscanf(const char *, const char *, ...);
+
+FILE *fopen(const char *, const char *);
+int fclose(FILE *);
+size_t fread(void *, size_t, size_t, FILE *);
+size_t fwrite(const void *buffer, size_t size, size_t count, FILE *stream);
+int fprintf(FILE *, const char *, ...);
+
+int vasprintf(char **s, const char *fmt, va_list ap);
+int asprintf(char **s, const char *fmt, ...);
+int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap);
+int vsprintf(char *restrict s, const char *restrict fmt, va_list ap);
+int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...);
+int sprintf(char *restrict s, const char *restrict fmt, ...);
+int dprintf(int fd, const char *__restrict fmt, ...);
+int vdprintf(int fd, const char *restrict fmt, va_list ap);
+
+// inet.h
+
+int inet_pton(int, const char *, void *);
+
+// setjmp.h
+
+int setjmp (jmp_buf) __setjmp_attr;
+_Noreturn void longjmp (jmp_buf, int);
+
+// assert.h
+
+#define assert(x) ((void)((x) || (__assert_fail(#x, __FILE__, __LINE__, __func__),0)))
+_Noreturn void __assert_fail (const char *, const char *, int, const char *);
+
+#endif

--- a/external/libcrt/include/limits.h
+++ b/external/libcrt/include/limits.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/memory.h
+++ b/external/libcrt/include/memory.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/stdarg.h
+++ b/external/libcrt/include/stdarg.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/stdatomic.h
+++ b/external/libcrt/include/stdatomic.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/stdbool.h
+++ b/external/libcrt/include/stdbool.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/stddef.h
+++ b/external/libcrt/include/stddef.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/stdint.h
+++ b/external/libcrt/include/stdint.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/stdio.h
+++ b/external/libcrt/include/stdio.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/stdlib.h
+++ b/external/libcrt/include/stdlib.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/string.h
+++ b/external/libcrt/include/string.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/strings.h
+++ b/external/libcrt/include/strings.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/sys/shm.h
+++ b/external/libcrt/include/sys/shm.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/sys/stat.h
+++ b/external/libcrt/include/sys/stat.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/sys/syscall.h
+++ b/external/libcrt/include/sys/syscall.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/sys/time.h
+++ b/external/libcrt/include/sys/time.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/sys/types.h
+++ b/external/libcrt/include/sys/types.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/sys/utsname.h
+++ b/external/libcrt/include/sys/utsname.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/time.h
+++ b/external/libcrt/include/time.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/include/unistd.h
+++ b/external/libcrt/include/unistd.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/external/libcrt/src/ctype/isascii.c
+++ b/external/libcrt/src/ctype/isascii.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int isascii(int c)
+{
+	return !(c&~0x7f);
+}

--- a/external/libcrt/src/ctype/isdigit.c
+++ b/external/libcrt/src/ctype/isdigit.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isdigit(int c)
+{
+	return (unsigned)c-'0' < 10;
+}

--- a/external/libcrt/src/ctype/islower.c
+++ b/external/libcrt/src/ctype/islower.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int islower(int c)
+{
+	return (unsigned)c-'a' < 26;
+}

--- a/external/libcrt/src/ctype/isspace.c
+++ b/external/libcrt/src/ctype/isspace.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int isspace(int c)
+{
+	return c == ' ' || (unsigned)c-'\t' < 5;
+}

--- a/external/libcrt/src/ctype/isupper.c
+++ b/external/libcrt/src/ctype/isupper.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int isupper(int c)
+{
+	return (unsigned)c-'A' < 26;
+}

--- a/external/libcrt/src/ctype/tolower.c
+++ b/external/libcrt/src/ctype/tolower.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int tolower(int c)
+{
+	if (isupper(c)) return c | 32;
+	return c;
+}

--- a/external/libcrt/src/ctype/toupper.c
+++ b/external/libcrt/src/ctype/toupper.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int toupper(int c)
+{
+	if (islower(c)) return c & 0x5f;
+	return c;
+}

--- a/external/libcrt/src/exit/assert.c
+++ b/external/libcrt/src/exit/assert.c
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void __assert_fail(const char *expr, const char *file, int line, const char *func)
+{
+	printf("Assertion failed: %s (%s: %s: %d)\n", expr, file, func, line);
+    abort();
+}

--- a/external/libcrt/src/prng/rand.c
+++ b/external/libcrt/src/prng/rand.c
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static uint64_t seed;
+
+void srand(unsigned s)
+{
+	seed = s - 1;
+}
+
+/* return 0 on success */
+static inline int rdrand64(uint64_t *rnd)
+{
+    unsigned char ok;
+
+    __asm__ volatile("rdrand %0; setc %1":"=r"(*rnd), "=qm"(ok));
+
+    return (ok) ? 0 : -1;
+}
+
+int rand(void)
+{
+  uint64_t r = 0;
+
+  if (rdrand64(&r)) {
+    printf("%s, RDRAND failed\n", __func__);
+  }
+
+  return r;
+}

--- a/external/libcrt/src/setjmp/x86_64/longjmp.s
+++ b/external/libcrt/src/setjmp/x86_64/longjmp.s
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright 2011-2012 Nicholas J. Kain, licensed under standard MIT license */
+
+.global _longjmp
+.global longjmp
+.type _longjmp,@function
+.type longjmp,@function
+_longjmp:
+longjmp:
+	xor %eax,%eax
+	cmp $1,%esi             /* CF = val ? 0 : 1 */
+	adc %esi,%eax           /* eax = val + !val */
+	mov (%rdi),%rbx         /* rdi is the jmp_buf, restore regs from it */
+	mov 8(%rdi),%rbp
+	mov 16(%rdi),%r12
+	mov 24(%rdi),%r13
+	mov 32(%rdi),%r14
+	mov 40(%rdi),%r15
+	mov 48(%rdi),%rsp
+	jmp *56(%rdi)           /* goto saved address without altering rsp */

--- a/external/libcrt/src/setjmp/x86_64/setjmp.s
+++ b/external/libcrt/src/setjmp/x86_64/setjmp.s
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright 2011-2012 Nicholas J. Kain, licensed under standard MIT license */
+
+.global __setjmp
+.global _setjmp
+.global setjmp
+.type __setjmp,@function
+.type _setjmp,@function
+.type setjmp,@function
+__setjmp:
+_setjmp:
+setjmp:
+	mov %rbx,(%rdi)         /* rdi is jmp_buf, move registers onto it */
+	mov %rbp,8(%rdi)
+	mov %r12,16(%rdi)
+	mov %r13,24(%rdi)
+	mov %r14,32(%rdi)
+	mov %r15,40(%rdi)
+	lea 8(%rsp),%rdx        /* this is our rsp WITHOUT current ret addr */
+	mov %rdx,48(%rdi)
+	mov (%rsp),%rdx         /* save return addr ptr for new rip */
+	mov %rdx,56(%rdi)
+	xor %eax,%eax           /* always return 0 */
+	ret

--- a/external/libcrt/src/stdio/asprintf.c
+++ b/external/libcrt/src/stdio/asprintf.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int asprintf(char **s, const char *fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vasprintf(s, fmt, ap);
+	va_end(ap);
+	return ret;
+}

--- a/external/libcrt/src/stdio/fprintf.c
+++ b/external/libcrt/src/stdio/fprintf.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int fprintf(FILE *restrict f, const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vprints(fmt, ap);
+	va_end(ap);
+	return ret;
+}

--- a/external/libcrt/src/stdio/printf.c
+++ b/external/libcrt/src/stdio/printf.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int printf(const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vprints(fmt, ap);
+	va_end(ap);
+	return ret;
+}
+
+int dprintf(int fd, const char *__restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vprints(fmt, ap);
+	va_end(ap);
+	return ret;
+}
+
+int vdprintf(int fd, const char *restrict fmt, va_list ap)
+{
+  return vprints(fmt, ap);
+}
+
+int puts(const char *s)
+{
+        return printf("%s\n", s);
+}

--- a/external/libcrt/src/stdio/printf_wrapper.c
+++ b/external/libcrt/src/stdio/printf_wrapper.c
@@ -1,0 +1,269 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+enum {
+	LEN_MOD_INVALID		= 0,
+	LEN_MOD_HALF_HALF,
+	LEN_MOD_HALF,
+	LEN_MOD_INT,
+	LEN_MOD_LONG,
+	LEN_MOD_LONG_LONG,
+	LEN_MOD_MAX
+};
+
+static char *format_string(char *cur, char *end, va_list ap)
+{
+	char *tmp = va_arg(ap, char *);
+
+	while (*tmp) {
+		if (cur < end)
+			*cur = *tmp;
+		cur++;
+		tmp++;
+	}
+
+	return cur;
+}
+
+static char *format_base16(char *cur, char *end, int width, va_list ap)
+{
+	unsigned long long num;
+	char *tmp, buffer[32];
+	unsigned int size;
+	char *map;
+
+	map = "0123456789abcdef";
+
+	if (cur < end)
+		*cur++ = '0';
+	if (cur < end)
+		*cur++ = 'x';
+
+	if (width == LEN_MOD_HALF_HALF) {
+		unsigned char n = (unsigned char) va_arg(ap, int);
+		num = (unsigned long long)n;
+		size = 1;
+	} else if (width == LEN_MOD_HALF) {
+		unsigned short n = (unsigned short) va_arg(ap, int);
+		num = (unsigned long long)n;
+		size = 2;
+	} else if (width == LEN_MOD_INT) {
+		unsigned int n = (unsigned int) va_arg(ap, int);
+		num = (unsigned long long)n;
+		size = 4;
+	} else if (width == LEN_MOD_LONG) {
+		unsigned long n = (unsigned long) va_arg(ap, long);
+		num = (unsigned long long)n;
+		size = 8;
+	} else {
+		unsigned long long n = (unsigned long long) va_arg(ap, long long);
+		num = (unsigned long long)n;
+		size = 8;
+	}
+
+	tmp = buffer + sizeof(buffer);
+
+	tmp--;
+	*tmp = '\0';
+	while (size--) {
+		tmp--;
+		*tmp = map[num & 0xf];
+		num >>= 4;
+
+		tmp--;
+		*tmp = map[num & 0xf];
+		num >>= 4;
+	}
+
+	while (*tmp) {
+		if (cur < end)
+			*cur = *tmp;
+		cur++;
+		tmp++;
+	}
+
+	return cur;
+}
+
+static char *format_base10(char *cur, char *end, int width, bool signed_format, va_list ap)
+{
+	unsigned long long num;
+	char *tmp, buffer[32];
+
+	if (width == LEN_MOD_HALF_HALF) {
+		unsigned char n = (unsigned char) va_arg(ap, int);
+		if (signed_format && (char)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(char)n;
+		}
+		num = (unsigned long long)n;
+	} else if (width == LEN_MOD_HALF) {
+		unsigned short n = (unsigned short) va_arg(ap, int);
+		if (signed_format && (short)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(short)n;
+		}
+		num = (unsigned long long)n;
+	} else if (width == LEN_MOD_INT) {
+		unsigned int n = (unsigned int) va_arg(ap, int);
+		if (signed_format && (int)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(int)n;
+		}
+		num = (unsigned long long)n;
+	} else if (width == LEN_MOD_LONG) {
+		unsigned long n = (unsigned long) va_arg(ap, long);
+		if (signed_format && (long)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(long)n;
+		}
+		num = (unsigned long long)n;
+	} else {
+		unsigned long long n = (unsigned long long) va_arg(ap, long long);
+		if (signed_format && (long long)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(long long)n;
+		}
+		num = (unsigned long long)n;
+	}
+
+	tmp = buffer + sizeof(buffer);
+
+	tmp--;
+	*tmp = '\0';
+	do {
+		tmp--;
+		*tmp = (char)('0' + num % 10);
+
+		num /= 10;
+	} while (num);
+
+	while (*tmp) {
+		if (cur < end)
+			*cur = *tmp;
+
+		cur++;
+		tmp++;
+	}
+
+	return cur;
+}
+
+int vsnprints(char *str, size_t size, const char *format, va_list ap)
+{
+	unsigned int width;
+	char *cur, *end;
+	bool convert;
+
+	cur = str;
+	end = cur + size;
+	if (end < cur) {
+		end = (void *)-1;
+		size = end - cur;
+	}
+
+	convert = false;
+	while (*format) {
+		if (!convert) {
+			if (*format != '%') {
+				if (cur < end)
+					*cur = *format;
+
+				cur++;
+				format++;
+				continue;
+			}
+
+			format++;
+			if (*format == '%') {
+				if (cur < end)
+					*cur = '%';
+
+				cur++;
+				format++;
+				continue;
+			}
+
+			convert = true;
+			width = LEN_MOD_INT;
+		} else {
+			bool signed_format = false;
+
+			switch (*format) {
+			case 'h':
+				width--;
+				if (width == LEN_MOD_INVALID)
+					convert = false;
+				break;
+			case 'l':
+				width++;
+				if (width == LEN_MOD_MAX)
+					convert = false;
+				break;
+
+			case 'd':
+				signed_format = true;
+			case 'u':
+				cur = format_base10(cur, end, width, signed_format, ap);
+				convert = false;
+				break;
+
+			case 'p':
+				width = LEN_MOD_LONG;
+			case 'x':
+				cur = format_base16(cur, end, width, ap);
+				convert = false;
+				break;
+
+			case 's': {
+				cur = format_string(cur, end, ap);
+				convert = false;
+				break;
+			}
+
+			default:
+				convert = false;
+			}
+
+			format++;
+		}
+	}
+
+	if (size) {
+		if (cur < end)
+			*cur = '\0';
+		else
+			*(end - 1) = '\0';
+	}
+
+	return cur - str;
+}
+
+// A format string is converted to the actual string, which is then
+// truncated to PRINT_STR_MAX before printing.
+#define PRINT_STR_MAX    256
+
+int vprints(const char *format, va_list ap)
+{
+	char buffer[PRINT_STR_MAX];
+	int ret;
+
+	ret = vsnprints(buffer, sizeof(buffer), format, ap);
+
+	if (ret >= sizeof(buffer)) {
+        ret = PRINT_STR_MAX;
+		buffer[PRINT_STR_MAX - 1] = '\0';
+    }
+
+	serial_out(buffer, ret);
+
+	return ret;
+}

--- a/external/libcrt/src/stdio/snprintf.c
+++ b/external/libcrt/src/stdio/snprintf.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vsnprintf(s, n, fmt, ap);
+	va_end(ap);
+	return ret;
+}
+

--- a/external/libcrt/src/stdio/sprintf.c
+++ b/external/libcrt/src/stdio/sprintf.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int sprintf(char *restrict s, const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vsprintf(s, fmt, ap);
+	va_end(ap);
+	return ret;
+}

--- a/external/libcrt/src/stdio/vasprintf.c
+++ b/external/libcrt/src/stdio/vasprintf.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+int vasprintf(char **s, const char *fmt, va_list ap)
+{
+	va_list ap2;
+	va_copy(ap2, ap);
+	int l = vsnprintf(0, 0, fmt, ap2);
+	va_end(ap2);
+
+	if (l<0 || !(*s=malloc(l+1U))) return -1;
+	return vsnprintf(*s, l+1U, fmt, ap);
+}

--- a/external/libcrt/src/stdio/vsnprintf.c
+++ b/external/libcrt/src/stdio/vsnprintf.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdarg.h>
+
+int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap)
+{
+	return vsnprints(s, n, fmt, ap);
+}

--- a/external/libcrt/src/stdio/vsprintf.c
+++ b/external/libcrt/src/stdio/vsprintf.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <limits.h>
+
+int vsprintf(char *restrict s, const char *restrict fmt, va_list ap)
+{
+	return vsnprintf(s, INT_MAX, fmt, ap);
+}

--- a/external/libcrt/src/stdlib/atoi.c
+++ b/external/libcrt/src/stdlib/atoi.c
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdlib.h>
+#include <ctype.h>
+
+int atoi(const char *s)
+{
+	int n=0, neg=0;
+	while (isspace(*s)) s++;
+	switch (*s) {
+	case '-': neg=1;
+	case '+': s++;
+	}
+	/* Compute n as a negative number to avoid overflow on INT_MIN */
+	while (isdigit(*s))
+		n = 10*n - (*s++ - '0');
+	return neg ? n : -n;
+}

--- a/external/libcrt/src/stdlib/qsort.c
+++ b/external/libcrt/src/stdlib/qsort.c
@@ -1,0 +1,221 @@
+/* Copyright (C) 2011 by Valentin Ochs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/* Minor changes by Rich Felker for integration in musl, 2011-04-27. */
+
+/* Smoothsort, an adaptive variant of Heapsort.  Memory usage: O(1).
+   Run time: Worst case O(n log n), close to O(n) in the mostly-sorted case. */
+
+#define _BSD_SOURCE
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "atomic.h"
+#define ntz(x) a_ctz_l((x))
+
+typedef int (*cmpfun)(const void *, const void *, void *);
+
+static inline int pntz(size_t p[2]) {
+	int r = ntz(p[0] - 1);
+	if(r != 0 || (r = 8*sizeof(size_t) + ntz(p[1])) != 8*sizeof(size_t)) {
+		return r;
+	}
+	return 0;
+}
+
+static void cycle(size_t width, unsigned char* ar[], int n)
+{
+	unsigned char tmp[256];
+	size_t l;
+	int i;
+
+	if(n < 2) {
+		return;
+	}
+
+	ar[n] = tmp;
+	while(width) {
+		l = sizeof(tmp) < width ? sizeof(tmp) : width;
+		memcpy(ar[n], ar[0], l);
+		for(i = 0; i < n; i++) {
+			memcpy(ar[i], ar[i + 1], l);
+			ar[i] += l;
+		}
+		width -= l;
+	}
+}
+
+/* shl() and shr() need n > 0 */
+static inline void shl(size_t p[2], int n)
+{
+	if(n >= 8 * sizeof(size_t)) {
+		n -= 8 * sizeof(size_t);
+		p[1] = p[0];
+		p[0] = 0;
+	}
+	p[1] <<= n;
+	p[1] |= p[0] >> (sizeof(size_t) * 8 - n);
+	p[0] <<= n;
+}
+
+static inline void shr(size_t p[2], int n)
+{
+	if(n >= 8 * sizeof(size_t)) {
+		n -= 8 * sizeof(size_t);
+		p[0] = p[1];
+		p[1] = 0;
+	}
+	p[0] >>= n;
+	p[0] |= p[1] << (sizeof(size_t) * 8 - n);
+	p[1] >>= n;
+}
+
+static void sift(unsigned char *head, size_t width, cmpfun cmp, void *arg, int pshift, size_t lp[])
+{
+	unsigned char *rt, *lf;
+	unsigned char *ar[14 * sizeof(size_t) + 1];
+	int i = 1;
+
+	ar[0] = head;
+	while(pshift > 1) {
+		rt = head - width;
+		lf = head - width - lp[pshift - 2];
+
+		if(cmp(ar[0], lf, arg) >= 0 && cmp(ar[0], rt, arg) >= 0) {
+			break;
+		}
+		if(cmp(lf, rt, arg) >= 0) {
+			ar[i++] = lf;
+			head = lf;
+			pshift -= 1;
+		} else {
+			ar[i++] = rt;
+			head = rt;
+			pshift -= 2;
+		}
+	}
+	cycle(width, ar, i);
+}
+
+static void trinkle(unsigned char *head, size_t width, cmpfun cmp, void *arg, size_t pp[2], int pshift, int trusty, size_t lp[])
+{
+	unsigned char *stepson,
+	              *rt, *lf;
+	size_t p[2];
+	unsigned char *ar[14 * sizeof(size_t) + 1];
+	int i = 1;
+	int trail;
+
+	p[0] = pp[0];
+	p[1] = pp[1];
+
+	ar[0] = head;
+	while(p[0] != 1 || p[1] != 0) {
+		stepson = head - lp[pshift];
+		if(cmp(stepson, ar[0], arg) <= 0) {
+			break;
+		}
+		if(!trusty && pshift > 1) {
+			rt = head - width;
+			lf = head - width - lp[pshift - 2];
+			if(cmp(rt, stepson, arg) >= 0 || cmp(lf, stepson, arg) >= 0) {
+				break;
+			}
+		}
+
+		ar[i++] = stepson;
+		head = stepson;
+		trail = pntz(p);
+		shr(p, trail);
+		pshift += trail;
+		trusty = 0;
+	}
+	if(!trusty) {
+		cycle(width, ar, i);
+		sift(head, width, cmp, arg, pshift, lp);
+	}
+}
+
+void __qsort_r(void *base, size_t nel, size_t width, cmpfun cmp, void *arg)
+{
+	size_t lp[12*sizeof(size_t)];
+	size_t i, size = width * nel;
+	unsigned char *head, *high;
+	size_t p[2] = {1, 0};
+	int pshift = 1;
+	int trail;
+
+	if (!size) return;
+
+	head = base;
+	high = head + size - width;
+
+	/* Precompute Leonardo numbers, scaled by element width */
+	for(lp[0]=lp[1]=width, i=2; (lp[i]=lp[i-2]+lp[i-1]+width) < size; i++);
+
+	while(head < high) {
+		if((p[0] & 3) == 3) {
+			sift(head, width, cmp, arg, pshift, lp);
+			shr(p, 2);
+			pshift += 2;
+		} else {
+			if(lp[pshift - 1] >= high - head) {
+				trinkle(head, width, cmp, arg, p, pshift, 0, lp);
+			} else {
+				sift(head, width, cmp, arg, pshift, lp);
+			}
+
+			if(pshift == 1) {
+				shl(p, 1);
+				pshift = 0;
+			} else {
+				shl(p, pshift - 1);
+				pshift = 1;
+			}
+		}
+
+		p[0] |= 1;
+		head += width;
+	}
+
+	trinkle(head, width, cmp, arg, p, pshift, 0, lp);
+
+	while(pshift != 1 || p[0] != 1 || p[1] != 0) {
+		if(pshift <= 1) {
+			trail = pntz(p);
+			shr(p, trail);
+			pshift += trail;
+		} else {
+			shl(p, 2);
+			pshift -= 2;
+			p[0] ^= 7;
+			shr(p, 1);
+			trinkle(head - lp[pshift] - width, width, cmp, arg, p, pshift + 1, 1, lp);
+			shl(p, 1);
+			p[0] |= 1;
+			trinkle(head - width, width, cmp, arg, p, pshift, 1, lp);
+		}
+		head -= width;
+	}
+}
+
+weak_alias(__qsort_r, qsort_r);

--- a/external/libcrt/src/stdlib/qsort_nr.c
+++ b/external/libcrt/src/stdlib/qsort_nr.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT */
+
+#define _BSD_SOURCE
+#include <stdlib.h>
+
+typedef int (*cmpfun)(const void *, const void *);
+
+static int wrapper_cmp(const void *v1, const void *v2, void *cmp)
+{
+	return ((cmpfun)cmp)(v1, v2);
+}
+
+void qsort(void *base, size_t nel, size_t width, cmpfun cmp)
+{
+	__qsort_r(base, nel, width, wrapper_cmp, (void *)cmp);
+}

--- a/external/libcrt/src/string/memchr.c
+++ b/external/libcrt/src/string/memchr.c
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define SS (sizeof(size_t))
+#define ALIGN (sizeof(size_t)-1)
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+void *memchr(const void *src, int c, size_t n)
+{
+	const unsigned char *s = src;
+	c = (unsigned char)c;
+#ifdef __GNUC__
+	for (; ((uintptr_t)s & ALIGN) && n && *s != c; s++, n--);
+	if (n && *s != c) {
+		typedef size_t __attribute__((__may_alias__)) word;
+		const word *w;
+		size_t k = ONES * c;
+		for (w = (const void *)s; n>=SS && !HASZERO(*w^k); w++, n-=SS);
+		s = (const void *)w;
+	}
+#endif
+	for (; n && *s != c; s++, n--);
+	return n ? (void *)s : 0;
+}

--- a/external/libcrt/src/string/memcmp.c
+++ b/external/libcrt/src/string/memcmp.c
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+int memcmp(const void *vl, const void *vr, size_t n)
+{
+	const unsigned char *l=vl, *r=vr;
+	for (; n && *l == *r; n--, l++, r++);
+	return n ? *l-*r : 0;
+}

--- a/external/libcrt/src/string/memcpy.c
+++ b/external/libcrt/src/string/memcpy.c
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <endian.h>
+
+void *memcpy(void *restrict dest, const void *restrict src, size_t n)
+{
+	unsigned char *d = dest;
+	const unsigned char *s = src;
+
+#ifdef __GNUC__
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define LS >>
+#define RS <<
+#else
+#define LS <<
+#define RS >>
+#endif
+
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	uint32_t w, x;
+
+	for (; (uintptr_t)s % 4 && n; n--) *d++ = *s++;
+
+	if ((uintptr_t)d % 4 == 0) {
+		for (; n>=16; s+=16, d+=16, n-=16) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			*(u32 *)(d+4) = *(u32 *)(s+4);
+			*(u32 *)(d+8) = *(u32 *)(s+8);
+			*(u32 *)(d+12) = *(u32 *)(s+12);
+		}
+		if (n&8) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			*(u32 *)(d+4) = *(u32 *)(s+4);
+			d += 8; s += 8;
+		}
+		if (n&4) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			d += 4; s += 4;
+		}
+		if (n&2) {
+			*d++ = *s++; *d++ = *s++;
+		}
+		if (n&1) {
+			*d = *s;
+		}
+		return dest;
+	}
+
+	if (n >= 32) switch ((uintptr_t)d % 4) {
+	case 1:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		n -= 3;
+		for (; n>=17; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+1);
+			*(u32 *)(d+0) = (w LS 24) | (x RS 8);
+			w = *(u32 *)(s+5);
+			*(u32 *)(d+4) = (x LS 24) | (w RS 8);
+			x = *(u32 *)(s+9);
+			*(u32 *)(d+8) = (w LS 24) | (x RS 8);
+			w = *(u32 *)(s+13);
+			*(u32 *)(d+12) = (x LS 24) | (w RS 8);
+		}
+		break;
+	case 2:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		*d++ = *s++;
+		n -= 2;
+		for (; n>=18; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+2);
+			*(u32 *)(d+0) = (w LS 16) | (x RS 16);
+			w = *(u32 *)(s+6);
+			*(u32 *)(d+4) = (x LS 16) | (w RS 16);
+			x = *(u32 *)(s+10);
+			*(u32 *)(d+8) = (w LS 16) | (x RS 16);
+			w = *(u32 *)(s+14);
+			*(u32 *)(d+12) = (x LS 16) | (w RS 16);
+		}
+		break;
+	case 3:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		n -= 1;
+		for (; n>=19; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+3);
+			*(u32 *)(d+0) = (w LS 8) | (x RS 24);
+			w = *(u32 *)(s+7);
+			*(u32 *)(d+4) = (x LS 8) | (w RS 24);
+			x = *(u32 *)(s+11);
+			*(u32 *)(d+8) = (w LS 8) | (x RS 24);
+			w = *(u32 *)(s+15);
+			*(u32 *)(d+12) = (x LS 8) | (w RS 24);
+		}
+		break;
+	}
+	if (n&16) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&8) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&4) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&2) {
+		*d++ = *s++; *d++ = *s++;
+	}
+	if (n&1) {
+		*d = *s;
+	}
+	return dest;
+#endif
+
+	for (; n; n--) *d++ = *s++;
+	return dest;
+}

--- a/external/libcrt/src/string/memmove.c
+++ b/external/libcrt/src/string/memmove.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+
+#ifdef __GNUC__
+typedef __attribute__((__may_alias__)) size_t WT;
+#define WS (sizeof(WT))
+#endif
+
+void *memmove(void *dest, const void *src, size_t n)
+{
+	char *d = dest;
+	const char *s = src;
+
+	if (d==s) return d;
+	if ((uintptr_t)s-(uintptr_t)d-n <= -2*n) return memcpy(d, s, n);
+
+	if (d<s) {
+#ifdef __GNUC__
+		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
+			while ((uintptr_t)d % WS) {
+				if (!n--) return dest;
+				*d++ = *s++;
+			}
+			for (; n>=WS; n-=WS, d+=WS, s+=WS) *(WT *)d = *(WT *)s;
+		}
+#endif
+		for (; n; n--) *d++ = *s++;
+	} else {
+#ifdef __GNUC__
+		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
+			while ((uintptr_t)(d+n) % WS) {
+				if (!n--) return dest;
+				d[n] = s[n];
+			}
+			while (n>=WS) n-=WS, *(WT *)(d+n) = *(WT *)(s+n);
+		}
+#endif
+		while (n) n--, d[n] = s[n];
+	}
+
+	return dest;
+}

--- a/external/libcrt/src/string/memrchr.c
+++ b/external/libcrt/src/string/memrchr.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+void *__memrchr(const void *m, int c, size_t n)
+{
+	const unsigned char *s = m;
+	c = (unsigned char)c;
+	while (n--) if (s[n]==c) return (void *)(s+n);
+	return 0;
+}
+
+weak_alias(__memrchr, memrchr);

--- a/external/libcrt/src/string/memset.c
+++ b/external/libcrt/src/string/memset.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+
+void *memset(void *dest, int c, size_t n)
+{
+	unsigned char *s = dest;
+	size_t k;
+
+	/* Fill head and tail with minimal branching. Each
+	 * conditional ensures that all the subsequently used
+	 * offsets are well-defined and in the dest region. */
+
+	if (!n) return dest;
+	s[0] = c;
+	s[n-1] = c;
+	if (n <= 2) return dest;
+	s[1] = c;
+	s[2] = c;
+	s[n-2] = c;
+	s[n-3] = c;
+	if (n <= 6) return dest;
+	s[3] = c;
+	s[n-4] = c;
+	if (n <= 8) return dest;
+
+	/* Advance pointer to align it at a 4-byte boundary,
+	 * and truncate n to a multiple of 4. The previous code
+	 * already took care of any head/tail that get cut off
+	 * by the alignment. */
+
+	k = -(uintptr_t)s & 3;
+	s += k;
+	n -= k;
+	n &= -4;
+
+#ifdef __GNUC__
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	typedef uint64_t __attribute__((__may_alias__)) u64;
+
+	u32 c32 = ((u32)-1)/255 * (unsigned char)c;
+
+	/* In preparation to copy 32 bytes at a time, aligned on
+	 * an 8-byte bounary, fill head/tail up to 28 bytes each.
+	 * As in the initial byte-based head/tail fill, each
+	 * conditional below ensures that the subsequent offsets
+	 * are valid (e.g. !(n<=24) implies n>=28). */
+
+	*(u32 *)(s+0) = c32;
+	*(u32 *)(s+n-4) = c32;
+	if (n <= 8) return dest;
+	*(u32 *)(s+4) = c32;
+	*(u32 *)(s+8) = c32;
+	*(u32 *)(s+n-12) = c32;
+	*(u32 *)(s+n-8) = c32;
+	if (n <= 24) return dest;
+	*(u32 *)(s+12) = c32;
+	*(u32 *)(s+16) = c32;
+	*(u32 *)(s+20) = c32;
+	*(u32 *)(s+24) = c32;
+	*(u32 *)(s+n-28) = c32;
+	*(u32 *)(s+n-24) = c32;
+	*(u32 *)(s+n-20) = c32;
+	*(u32 *)(s+n-16) = c32;
+
+	/* Align to a multiple of 8 so we can fill 64 bits at a time,
+	 * and avoid writing the same bytes twice as much as is
+	 * practical without introducing additional branching. */
+
+	k = 24 + ((uintptr_t)s & 4);
+	s += k;
+	n -= k;
+
+	/* If this loop is reached, 28 tail bytes have already been
+	 * filled, so any remainder when n drops below 32 can be
+	 * safely ignored. */
+
+	u64 c64 = c32 | ((u64)c32 << 32);
+	for (; n >= 32; n-=32, s+=32) {
+		*(u64 *)(s+0) = c64;
+		*(u64 *)(s+8) = c64;
+		*(u64 *)(s+16) = c64;
+		*(u64 *)(s+24) = c64;
+	}
+#else
+	/* Pure C fallback with no aliasing violations. */
+	for (; n; n--, s++) *s = c;
+#endif
+
+	return dest;
+}

--- a/external/libcrt/src/string/stpcpy.c
+++ b/external/libcrt/src/string/stpcpy.c
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t))
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+char *__stpcpy(char *restrict d, const char *restrict s)
+{
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	word *wd;
+	const word *ws;
+	if ((uintptr_t)s % ALIGN == (uintptr_t)d % ALIGN) {
+		for (; (uintptr_t)s % ALIGN; s++, d++)
+			if (!(*d=*s)) return d;
+		wd=(void *)d; ws=(const void *)s;
+		for (; !HASZERO(*ws); *wd++ = *ws++);
+		d=(void *)wd; s=(const void *)ws;
+	}
+#endif
+	for (; (*d=*s); s++, d++);
+
+	return d;
+}
+
+weak_alias(__stpcpy, stpcpy);

--- a/external/libcrt/src/string/stpncpy.c
+++ b/external/libcrt/src/string/stpncpy.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t)-1)
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+char *__stpncpy(char *restrict d, const char *restrict s, size_t n)
+{
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	word *wd;
+	const word *ws;
+	if (((uintptr_t)s & ALIGN) == ((uintptr_t)d & ALIGN)) {
+		for (; ((uintptr_t)s & ALIGN) && n && (*d=*s); n--, s++, d++);
+		if (!n || !*s) goto tail;
+		wd=(void *)d; ws=(const void *)s;
+		for (; n>=sizeof(size_t) && !HASZERO(*ws);
+		       n-=sizeof(size_t), ws++, wd++) *wd = *ws;
+		d=(void *)wd; s=(const void *)ws;
+	}
+#endif
+	for (; n && (*d=*s); n--, s++, d++);
+tail:
+	memset(d, 0, n);
+	return d;
+}
+
+weak_alias(__stpncpy, stpncpy);
+

--- a/external/libcrt/src/string/strcasecmp.c
+++ b/external/libcrt/src/string/strcasecmp.c
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <strings.h>
+#include <ctype.h>
+
+int strcasecmp(const char *_l, const char *_r)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	for (; *l && *r && (*l == *r || tolower(*l) == tolower(*r)); l++, r++);
+	return tolower(*l) - tolower(*r);
+}
+
+#if 0
+int __strcasecmp_l(const char *l, const char *r, locale_t loc)
+{
+	return strcasecmp(l, r);
+}
+
+weak_alias(__strcasecmp_l, strcasecmp_l);
+#endif

--- a/external/libcrt/src/string/strcat.c
+++ b/external/libcrt/src/string/strcat.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strcat(char *restrict dest, const char *restrict src)
+{
+	strcpy(dest + strlen(dest), src);
+	return dest;
+}

--- a/external/libcrt/src/string/strchr.c
+++ b/external/libcrt/src/string/strchr.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strchr(const char *s, int c)
+{
+	char *r = __strchrnul(s, c);
+	return *(unsigned char *)r == (unsigned char)c ? r : 0;
+}

--- a/external/libcrt/src/string/strchrnul.c
+++ b/external/libcrt/src/string/strchrnul.c
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t))
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+char *__strchrnul(const char *s, int c)
+{
+	c = (unsigned char)c;
+	if (!c) return (char *)s + strlen(s);
+
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	const word *w;
+	for (; (uintptr_t)s % ALIGN; s++)
+		if (!*s || *(unsigned char *)s == c) return (char *)s;
+	size_t k = ONES * c;
+	for (w = (void *)s; !HASZERO(*w) && !HASZERO(*w^k); w++);
+	s = (void *)w;
+#endif
+	for (; *s && *(unsigned char *)s != c; s++);
+	return (char *)s;
+}
+
+weak_alias(__strchrnul, strchrnul);

--- a/external/libcrt/src/string/strcmp.c
+++ b/external/libcrt/src/string/strcmp.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+int strcmp(const char *l, const char *r)
+{
+	for (; *l==*r && *l; l++, r++);
+	return *(unsigned char *)l - *(unsigned char *)r;
+}

--- a/external/libcrt/src/string/strcpy.c
+++ b/external/libcrt/src/string/strcpy.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strcpy(char *restrict dest, const char *restrict src)
+{
+	__stpcpy(dest, src);
+	return dest;
+}

--- a/external/libcrt/src/string/strcspn.c
+++ b/external/libcrt/src/string/strcspn.c
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+size_t strcspn(const char *s, const char *c)
+{
+	const char *a = s;
+	size_t byteset[32/sizeof(size_t)];
+
+	if (!c[0] || !c[1]) return __strchrnul(s, *c)-a;
+
+	memset(byteset, 0, sizeof byteset);
+	for (; *c && BITOP(byteset, *(unsigned char *)c, |=); c++);
+	for (; *s && !BITOP(byteset, *(unsigned char *)s, &); s++);
+	return s-a;
+}

--- a/external/libcrt/src/string/strdup.c
+++ b/external/libcrt/src/string/strdup.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+char *strdup(const char *s)
+{
+	size_t l = strlen(s);
+	char *d = malloc(l+1);
+	if (!d) return NULL;
+	return memcpy(d, s, l+1);
+}

--- a/external/libcrt/src/string/strlen.c
+++ b/external/libcrt/src/string/strlen.c
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t))
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+size_t strlen(const char *s)
+{
+	const char *a = s;
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	const word *w;
+	for (; (uintptr_t)s % ALIGN; s++) if (!*s) return s-a;
+	for (w = (const void *)s; !HASZERO(*w); w++);
+	s = (const void *)w;
+#endif
+	for (; *s; s++);
+	return s-a;
+}

--- a/external/libcrt/src/string/strncasecmp.c
+++ b/external/libcrt/src/string/strncasecmp.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <strings.h>
+#include <ctype.h>
+
+int strncasecmp(const char *_l, const char *_r, size_t n)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	if (!n--) return 0;
+	for (; *l && *r && n && (*l == *r || tolower(*l) == tolower(*r)); l++, r++, n--);
+	return tolower(*l) - tolower(*r);
+}

--- a/external/libcrt/src/string/strncat.c
+++ b/external/libcrt/src/string/strncat.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strncat(char *restrict d, const char *restrict s, size_t n)
+{
+	char *a = d;
+	d += strlen(d);
+	while (n && *s) n--, *d++ = *s++;
+	*d++ = 0;
+	return a;
+}

--- a/external/libcrt/src/string/strncmp.c
+++ b/external/libcrt/src/string/strncmp.c
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+int strncmp(const char *_l, const char *_r, size_t n)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	if (!n--) return 0;
+	for (; *l && *r && n && *l == *r ; l++, r++, n--);
+	return *l - *r;
+}

--- a/external/libcrt/src/string/strncpy.c
+++ b/external/libcrt/src/string/strncpy.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strncpy(char *restrict d, const char *restrict s, size_t n)
+{
+	__stpncpy(d, s, n);
+	return d;
+}

--- a/external/libcrt/src/string/strrchr.c
+++ b/external/libcrt/src/string/strrchr.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strrchr(const char *s, int c)
+{
+	return __memrchr(s, c, strlen(s) + 1);
+}

--- a/external/libcrt/src/string/strspn.c
+++ b/external/libcrt/src/string/strspn.c
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+size_t strspn(const char *s, const char *c)
+{
+	const char *a = s;
+	size_t byteset[32/sizeof(size_t)] = { 0 };
+
+	if (!c[0]) return 0;
+	if (!c[1]) {
+		for (; *s == *c; s++);
+		return s-a;
+	}
+
+	for (; *c && BITOP(byteset, *(unsigned char *)c, |=); c++);
+	for (; *s && BITOP(byteset, *(unsigned char *)s, &); s++);
+	return s-a;
+}

--- a/external/libcrt/src/string/strstr.c
+++ b/external/libcrt/src/string/strstr.c
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+
+static char *twobyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint16_t nw = n[0]<<8 | n[1], hw = h[0]<<8 | h[1];
+	for (h++; *h && hw != nw; hw = hw<<8 | *++h);
+	return *h ? (char *)h-1 : 0;
+}
+
+static char *threebyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint32_t nw = (uint32_t)n[0]<<24 | n[1]<<16 | n[2]<<8;
+	uint32_t hw = (uint32_t)h[0]<<24 | h[1]<<16 | h[2]<<8;
+	for (h+=2; *h && hw != nw; hw = (hw|*++h)<<8);
+	return *h ? (char *)h-2 : 0;
+}
+
+static char *fourbyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint32_t nw = (uint32_t)n[0]<<24 | n[1]<<16 | n[2]<<8 | n[3];
+	uint32_t hw = (uint32_t)h[0]<<24 | h[1]<<16 | h[2]<<8 | h[3];
+	for (h+=3; *h && hw != nw; hw = hw<<8 | *++h);
+	return *h ? (char *)h-3 : 0;
+}
+
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
+{
+	const unsigned char *z;
+	size_t l, ip, jp, k, p, ms, p0, mem, mem0;
+	size_t byteset[32 / sizeof(size_t)] = { 0 };
+	size_t shift[256];
+
+	/* Computing length of needle and fill shift table */
+	for (l=0; n[l] && h[l]; l++)
+		BITOP(byteset, n[l], |=), shift[n[l]] = l+1;
+	if (n[l]) return 0; /* hit the end of h */
+
+	/* Compute maximal suffix */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] > n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	ms = ip;
+	p0 = p;
+
+	/* And with the opposite comparison */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] < n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	if (ip+1 > ms+1) ms = ip;
+	else p = p0;
+
+	/* Periodic needle? */
+	if (memcmp(n, n+p, ms+1)) {
+		mem0 = 0;
+		p = MAX(ms, l-ms-1) + 1;
+	} else mem0 = l-p;
+	mem = 0;
+
+	/* Initialize incremental end-of-haystack pointer */
+	z = h;
+
+	/* Search loop */
+	for (;;) {
+		/* Update incremental end-of-haystack pointer */
+		if (z-h < l) {
+			/* Fast estimate for MAX(l,63) */
+			size_t grow = l | 63;
+			const unsigned char *z2 = memchr(z, 0, grow);
+			if (z2) {
+				z = z2;
+				if (z-h < l) return 0;
+			} else z += grow;
+		}
+
+		/* Check last byte first; advance by shift on mismatch */
+		if (BITOP(byteset, h[l-1], &)) {
+			k = l-shift[h[l-1]];
+			if (k) {
+				if (k < mem) k = mem;
+				h += k;
+				mem = 0;
+				continue;
+			}
+		} else {
+			h += l;
+			mem = 0;
+			continue;
+		}
+
+		/* Compare right half */
+		for (k=MAX(ms+1,mem); n[k] && n[k] == h[k]; k++);
+		if (n[k]) {
+			h += k-ms;
+			mem = 0;
+			continue;
+		}
+		/* Compare left half */
+		for (k=ms+1; k>mem && n[k-1] == h[k-1]; k--);
+		if (k <= mem) return (char *)h;
+		h += p;
+		mem = mem0;
+	}
+}
+
+char *strstr(const char *h, const char *n)
+{
+	/* Return immediately on empty needle */
+	if (!n[0]) return (char *)h;
+
+	/* Use faster algorithms for short needles */
+	h = strchr(h, *n);
+	if (!h || !n[1]) return (char *)h;
+	if (!h[1]) return 0;
+	if (!n[2]) return twobyte_strstr((void *)h, (void *)n);
+	if (!h[2]) return 0;
+	if (!n[3]) return threebyte_strstr((void *)h, (void *)n);
+	if (!h[3]) return 0;
+	if (!n[4]) return fourbyte_strstr((void *)h, (void *)n);
+
+	return twoway_strstr((void *)h, (void *)n);
+}

--- a/external/libcrt/src/stub.c
+++ b/external/libcrt/src/stub.c
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>
+
+#define NOT_IMPLEMENTED printf("BUG: %s not implemented\n", __func__)
+
+// errno.h
+
+int  errno = 0;
+FILE  *stderr = NULL;
+FILE  *stdin  = NULL;
+FILE  *stdout = NULL;
+
+char *strerror(int errnum)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+// stdio.h
+
+int sscanf(const char  *buffer, const char  *format, ...)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+size_t fwrite(const void *buffer, size_t size, size_t count, FILE *stream)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+size_t fread(void *b, size_t c, size_t i, FILE *f)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+int fclose(FILE *f)
+{
+    NOT_IMPLEMENTED;
+    return EOF;
+}
+
+FILE *fopen(const char *c, const char *m)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+void setbuf(FILE *stream, char *buf)
+{
+    NOT_IMPLEMENTED;
+}
+
+// stdlib.h
+
+long strtol(const char *nptr, char **endptr, int base)
+{
+    NOT_IMPLEMENTED;
+    return LONG_MIN;
+}
+
+unsigned long strtoul(const char *nptr, char **endptr, int base)
+{
+    NOT_IMPLEMENTED;
+    return ULONG_MAX;
+}
+
+char *getenv(const char *varname)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+int atexit(void (*func)(void))
+{
+    NOT_IMPLEMENTED;
+	return -1;
+}
+
+// unistd.h
+
+static pid_t monotonic_counter;
+
+pid_t getpid(void)
+{
+    NOT_IMPLEMENTED;
+	return ++monotonic_counter;
+}
+
+uid_t getuid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+uid_t geteuid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+gid_t getgid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+gid_t getegid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+// dirent.h
+
+DIR *opendir(const char *name)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+int closedir(DIR *name)
+{
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+struct dirent *readdir(DIR *name)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+// sys/stat.h
+
+int stat(const char *__restrict path, struct stat *restrict buf)
+{
+    NOT_IMPLEMENTED;
+    return -1;
+}

--- a/external/libcrt/src/time/__secs_to_tm.c
+++ b/external/libcrt/src/time/__secs_to_tm.c
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <limits.h>
+#include <time.h>
+
+/* 2000-03-01 (mod 400 year, immediately after feb29 */
+#define LEAPOCH (946684800LL + 86400*(31+29))
+
+#define DAYS_PER_400Y (365*400 + 97)
+#define DAYS_PER_100Y (365*100 + 24)
+#define DAYS_PER_4Y   (365*4   + 1)
+
+int __secs_to_tm(long long t, struct tm *tm)
+{
+	long long days, secs, years;
+	int remdays, remsecs, remyears;
+	int qc_cycles, c_cycles, q_cycles;
+	int months;
+	int wday, yday, leap;
+	static const char days_in_month[] = {31,30,31,30,31,31,30,31,30,31,31,29};
+
+	/* Reject time_t values whose year would overflow int */
+	if (t < INT_MIN * 31622400LL || t > INT_MAX * 31622400LL)
+		return -1;
+
+	secs = t - LEAPOCH;
+	days = secs / 86400;
+	remsecs = secs % 86400;
+	if (remsecs < 0) {
+		remsecs += 86400;
+		days--;
+	}
+
+	wday = (3+days)%7;
+	if (wday < 0) wday += 7;
+
+	qc_cycles = days / DAYS_PER_400Y;
+	remdays = days % DAYS_PER_400Y;
+	if (remdays < 0) {
+		remdays += DAYS_PER_400Y;
+		qc_cycles--;
+	}
+
+	c_cycles = remdays / DAYS_PER_100Y;
+	if (c_cycles == 4) c_cycles--;
+	remdays -= c_cycles * DAYS_PER_100Y;
+
+	q_cycles = remdays / DAYS_PER_4Y;
+	if (q_cycles == 25) q_cycles--;
+	remdays -= q_cycles * DAYS_PER_4Y;
+
+	remyears = remdays / 365;
+	if (remyears == 4) remyears--;
+	remdays -= remyears * 365;
+
+	leap = !remyears && (q_cycles || !c_cycles);
+	yday = remdays + 31 + 28 + leap;
+	if (yday >= 365+leap) yday -= 365+leap;
+
+	years = remyears + 4*q_cycles + 100*c_cycles + 400LL*qc_cycles;
+
+	for (months=0; days_in_month[months] <= remdays; months++)
+		remdays -= days_in_month[months];
+
+	if (months >= 10) {
+		months -= 12;
+		years++;
+	}
+
+	if (years+100 > INT_MAX || years+100 < INT_MIN)
+		return -1;
+
+	tm->tm_year = years + 100;
+	tm->tm_mon = months + 2;
+	tm->tm_mday = remdays + 1;
+	tm->tm_wday = wday;
+	tm->tm_yday = yday;
+
+	tm->tm_hour = remsecs / 3600;
+	tm->tm_min = remsecs / 60 % 60;
+	tm->tm_sec = remsecs % 60;
+
+	return 0;
+}

--- a/external/libcrt/src/time/gmtime_r.c
+++ b/external/libcrt/src/time/gmtime_r.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <time.h>
+#include <errno.h>
+
+char *__utc = "UTC";
+
+struct tm *gmtime_r(const time_t *restrict t, struct tm *restrict tm)
+{
+	if (__secs_to_tm(*t, tm) < 0) {
+		errno = EOVERFLOW;
+		return 0;
+	}
+	tm->tm_isdst = 0;
+	tm->tm_gmtoff = 0;
+	tm->tm_zone = __utc;
+	return tm;
+}
+
+
+struct tm *gmtime(const time_t *t)
+{
+	static struct tm tm;
+	return gmtime_r(t, &tm);
+}

--- a/external/libcrt/src/time/time.c
+++ b/external/libcrt/src/time/time.c
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <time.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+// Calls the rdtsc instruction to read the current value of the processor's
+// time-stamp counter (a 64-bit MSR)
+clock_t clock(void) {
+	return rdtsc();
+}
+
+uint64_t secs;
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+	(void) clk_id;
+	if (tp) {
+		tp->tv_nsec = rdtsc();
+		tp->tv_sec = secs++;
+	}
+	return 0;
+}
+
+//  time() returns the time as the number of seconds since the Epoch
+time_t time(time_t *tloc) {
+	(void)tloc;
+	time_t t = rdtsc();
+	return t;
+}
+
+int gettimeofday(struct timeval *restrict tv, void *restrict tz)
+{
+        if (!tv) return 0;
+        tv->tv_sec = clock();
+        tv->tv_usec = 0;
+        return 0;
+}

--- a/external/openssl_svsm.conf
+++ b/external/openssl_svsm.conf
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2023 IBM Corporation
+#
+# Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+#
+
+my %targets = (
+    "SVSM" => {
+        inherit_from    => [ "BASE_unix" ],
+        perlasm_scheme  => "elf",
+        CC              => "gcc",
+        CFLAGS          => add("-O2 -fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector"),
+        bn_ops          => "SIXTY_FOUR_BIT_LONG",
+        lib_cppflags    => add("-DL_ENDIAN -DNO_SYSLOG -DOPENSSL_SMALL_FOOTPRINT -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE"),
+        sys_id          => "SVSM"
+    },
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub mod svsm_request;
 pub mod util;
 /// Handle the list of VMSA pages
 pub mod vmsa_list;
+/// Wrappers for external dependencies
+pub mod wrapper;
 
 extern crate alloc;
 

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -20,8 +20,8 @@ pub mod map_guard;
 pub mod pgtable;
 
 pub use crate::mem::alloc::{
-    mem_allocate, mem_allocate_frame, mem_allocate_frames, mem_create_stack, mem_free,
-    mem_free_frame, mem_free_frames, mem_init,
+    mem_allocate, mem_allocate_frame, mem_allocate_frames, mem_callocate, mem_create_stack,
+    mem_free, mem_free_frame, mem_free_frames, mem_init, mem_reallocate,
 };
 
 pub use crate::mem::pgtable::{

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Copyright (C) 2023 IBM
+ *
+ * Authors:
+ *   Claudio Carvalho <cclaudio@ibm.com>
+ *   Vikram Narayanan <vikram186@gmail.com>
+ */
+
+#![allow(non_camel_case_types)]
+
+use crate::cpu::vc_terminate_svsm_general;
+use crate::mem::{mem_allocate, mem_callocate, mem_free, mem_reallocate};
+use crate::prints;
+
+use core::{ptr, slice, str};
+use x86_64::VirtAddr;
+
+#[no_mangle]
+pub extern "C" fn malloc(size: cty::c_ulong) -> *mut cty::c_void {
+    if let Ok(va) = mem_allocate(size as usize) {
+        return va.as_mut_ptr();
+    };
+    ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn calloc(items: cty::c_ulong, size: cty::c_ulong) -> *mut cty::c_void {
+    if let Some(num_bytes) = items.checked_mul(size as u64) {
+        if let Ok(va) = mem_callocate(num_bytes as usize) {
+            return va.as_mut_ptr();
+        }
+    }
+    ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn realloc(p: *mut cty::c_void, size: cty::c_ulong) -> *mut cty::c_void {
+    if let Ok(va) = mem_reallocate(VirtAddr::new(p as u64), size as usize) {
+        return va.as_mut_ptr();
+    }
+    ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn free(p: *mut cty::c_void) {
+    if p.is_null() {
+        return;
+    }
+    mem_free(VirtAddr::new(p as u64));
+}
+
+#[no_mangle]
+pub extern "C" fn serial_out(s: *const cty::c_char, size: cty::c_int) {
+    let str_slice: &[u8] = unsafe { slice::from_raw_parts(s as *const u8, size as usize) };
+    if let Ok(rust_str) = str::from_utf8(str_slice) {
+        prints!("{}", rust_str);
+    } else {
+        prints!("ERR: BUG: serial_out arg1 is not a valid utf8 string\n");
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn abort() -> ! {
+    vc_terminate_svsm_general();
+}


### PR DESCRIPTION
Tom suggested to break the PR #35 into two PRs, one that adds the libcrt/openssl integration and one that adds support for the attestation protocol.

This PR adds the libcrt/openssl integration.

## How to test
```
make prereq_external
make external
make clean_all
```
In the next PR (the one that adds support for the attestation report protocol) I can wire up the build of external dependencies by modifying the _all_ target to depend on the _external_ target.
