### PR TITLE
Allow running simple unit tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,7 @@ build-std = ["core", "compiler_builtins", "alloc"]
 [build]
 target = "svsm-target.json"
 
+[target.svsm-target]
 rustflags = [
   "-C", "link-arg=-Tsrc/start/svsm.lds",
 ]

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ svsm.bin.elf: $(OBJS) src/start/svsm.lds
 %.lds: %.lds.S src/start/svsm.h
 	$(GCC) $(A_FLAGS) $(LDS_FLAGS) -E -P -o $@ $<
 
+test:
+	cargo test --features $(FEATURES) --target=x86_64-unknown-linux-gnu -Z build-std
+
 prereq: .prereq
 
 .prereq:

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ force prerequisites re-installation on the next execution of make do:
 # make superclean
 ```
 
+To run the unit tests:
+
+```
+# make test
+```
+
 ## Running Linux SVSM <a name="run"></a>
 
 The building process will generate svsm.bin that can be passed to Qemu (svsm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 // We cannot use the Rust runtime, Hence we don't have the C start point (C run time 0 aka crt0).
 // Tell the compiler we don't want to use the normal entry chain. Nobody calls main(), since we
 // overwrite _start().
-#![no_main]
+#![cfg_attr(not(test), no_main)]
 
 /// Initialize BIOS for the guest
 pub mod bios;
@@ -45,8 +45,10 @@ use crate::svsm_request::svsm_request_loop;
 use crate::util::*;
 use crate::vmsa::*;
 
+#[cfg(not(test))]
 use core::panic::PanicInfo;
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(panic_info: &PanicInfo) -> ! {
     prints!("PANIC!\n{}\nPANIC!\n", panic_info);

--- a/src/mem/alloc.rs
+++ b/src/mem/alloc.rs
@@ -1085,9 +1085,10 @@ unsafe impl GlobalAlloc for SvsmAllocator {
     }
 }
 
-#[global_allocator]
+#[cfg_attr(not(test), global_allocator)]
 pub static mut ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
 
+#[cfg(not(test))]
 #[alloc_error_handler]
 fn alloc_error_handler(layout: alloc::alloc::Layout) -> ! {
     panic!("Allocation failed: {:?}\n", layout)

--- a/src/vmsa_list.rs
+++ b/src/vmsa_list.rs
@@ -79,3 +79,41 @@ lazy_static! {
     /// Global list of VMSAs
     pub static ref VMSA_LIST: VmsaList = VmsaList::default();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_apic_id() {
+        let list: VmsaList = VmsaList::default();
+        list.push(PhysAddr::new(0x1000), 2);
+        list.push(PhysAddr::new(0x5000), 1);
+        assert_eq!(list.get_apic_id(PhysAddr::new(0x1000)), Some(2));
+        assert_eq!(list.get_apic_id(PhysAddr::new(0x5000)), Some(1));
+        assert_eq!(list.get_apic_id(PhysAddr::new(0x3000)), None);
+    }
+
+    #[test]
+    fn test_contains() {
+        let list: VmsaList = VmsaList::default();
+        list.push(PhysAddr::new(0x1000), 2);
+        list.push(PhysAddr::new(0x5000), 1);
+        assert_eq!(list.contains(PhysAddr::new(0x1000)), true);
+        assert_eq!(list.contains(PhysAddr::new(0x5000)), true);
+        assert_eq!(list.contains(PhysAddr::new(0x3000)), false);
+    }
+
+    #[test]
+    fn test_remove() {
+        let list: VmsaList = VmsaList::default();
+        list.push(PhysAddr::new(0x1000), 2);
+        list.push(PhysAddr::new(0x5000), 1);
+        assert_eq!(list.remove(PhysAddr::new(0x1000)), true);
+        assert_eq!(list.contains(PhysAddr::new(0x1000)), false);
+        assert_eq!(list.contains(PhysAddr::new(0x5000)), true);
+
+        // Test remove of non-existing vmsa
+        assert_eq!(list.remove(PhysAddr::new(0x3000)), false);
+    }
+}


### PR DESCRIPTION
Enable running simple unit tests with `make test`.

As a first case, the last commit adds unit tests for `VmsaList`.

This is useful only for "high-level" functions that don't map physical memory, access special CPU instructions, etc. I added this because I wanted to test the implementation of serializing Services Manifest (part of the attestation protocol).

Output example:

```
$ make test
cargo test --features "" --target=x86_64-unknown-linux-gnu -Z build-std
   Compiling linux_svsm v0.1.0 (/home/dov/linux-svsm)
    Finished test [unoptimized + debuginfo] target(s) in 0.73s
     Running unittests src/lib.rs (target/x86_64-unknown-linux-gnu/debug/deps/linux_svsm-51c1d10bd33e4db7)

running 3 tests
test vmsa_list::tests::test_contains ... ok
test vmsa_list::tests::test_get_apic_id ... ok
test vmsa_list::tests::test_remove ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
