### PR TITLE
wrapper: Fix `realloc()` extern declaration

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -70,7 +70,7 @@ mod test_wrappers {
     extern "C" {
         fn malloc(size: cty::c_ulong) -> *mut cty::c_void;
         fn calloc(items: cty::c_ulong, size: cty::c_ulong) -> *mut cty::c_void;
-        fn realloc(items: cty::c_ulong, size: cty::c_ulong) -> *mut cty::c_void;
+        fn realloc(p: *mut cty::c_void, size: cty::c_ulong) -> *mut cty::c_void;
         fn free(ptr: *mut cty::c_void);
     }
 }


### PR DESCRIPTION
Make `realloc()` declaration identical both in full build and test build.

Fixes: 3df655a378fd ("wrapper: Use libc functions when testing")
