### PR TITLE
Fixes for Rust 1.71

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "linux_svsm"
 authors = ["Tom Lendacky <thomas.lendacky@amd.com>", "Carlos Bilbao <carlos.bilbao@amd.com>"]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.71"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -13,6 +13,7 @@ use crate::*;
 
 use core::cmp::min;
 use core::mem::size_of;
+use core::ptr;
 use core::slice;
 use uuid::Bytes;
 use uuid::{uuid, Uuid};
@@ -200,7 +201,7 @@ fn find_bios_guid_entry(bios_info: &mut BiosInfo, target_guid: Uuid) -> Option<u
 }
 
 unsafe fn __find_snp_section(bios_info: &mut BiosInfo, stype: u32, p: u64) -> Option<SnpSection> {
-    let offset: u64 = *(p as *const u32) as u64;
+    let offset: u64 = ptr::read_unaligned(p as *const u32) as u64;
     if offset > bios_info.size() {
         return None;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 
 #![feature(type_ascription)]
 #![feature(abi_x86_interrupt)]
-#![feature(alloc_error_handler)]
 // Disable the (implicitly-linked) standard library. #! defines behavior of the current module; as
 // we are in root, the entire crate is affected.
 #![no_std]

--- a/src/mem/alloc.rs
+++ b/src/mem/alloc.rs
@@ -1141,12 +1141,6 @@ unsafe impl GlobalAlloc for SvsmAllocator {
 #[cfg_attr(not(test), global_allocator)]
 pub static mut ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
 
-#[cfg(not(test))]
-#[alloc_error_handler]
-fn alloc_error_handler(layout: alloc::alloc::Layout) -> ! {
-    panic!("Allocation failed: {:?}\n", layout)
-}
-
 /// Create a stack of size stack_pages and add a guard page
 /// also make the stack user accessible if needed
 pub fn mem_create_stack(stack_pages: u64, user_space: bool) -> VirtAddr {


### PR DESCRIPTION
1. Remove use of `alloc_error_handler`; declare minimal Rust version 1.71
2. Use read_unaligned to access u32 field in `__find_snp_section()`

Fixes #51 
